### PR TITLE
Use APISpec doc instead of default

### DIFF
--- a/app/api/models/resolver.py
+++ b/app/api/models/resolver.py
@@ -15,6 +15,7 @@ class SearchPayload(BaseModel):
 
 class SearchMatch(BaseModel):
     genome: str
+    unversioned_stable_id: str
 
 
 class SearchResult(BaseModel):

--- a/app/api/resources/resolver_view.py
+++ b/app/api/resources/resolver_view.py
@@ -51,9 +51,9 @@ async def resolve(
             continue
 
         if app == "entity-viewer":
-            url = f"{ENSEMBL_URL}/{app}/{genome_id}/{type}:{stable_id}"
+            url = f"{ENSEMBL_URL}/{app}/{genome_id}/{type}:{metadata['unversioned_stable_id']}"
         else:
-            url = f"{ENSEMBL_URL}/{app}/{genome_id}?focus={type}:{stable_id}"
+            url = f"{ENSEMBL_URL}/{app}/{genome_id}?focus={type}:{metadata['unversioned_stable_id']}"
 
         metadata["resolved_url"] = url
         resolved_payload = ResolvedPayload(**metadata)

--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -18,6 +18,9 @@ def get_metadata(matches: List[SearchMatch] = []):
             ) as response:
                 response.raise_for_status()
                 metadata_results[genome_id] = response.json()
+                metadata_results[genome_id]["unversioned_stable_id"] = match.get(
+                    "unversioned_stable_id"
+                )
         except requests.exceptions.HTTPError as HTTPError:
             logger.error(f"HTTPError: {HTTPError}")
             return None

--- a/app/main.py
+++ b/app/main.py
@@ -18,13 +18,21 @@ limitations under the License.
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from fastapi.openapi.docs import get_swagger_ui_html
 
 from api.resources.routes import router
 from core.config import API_PREFIX, ALLOWED_HOSTS, VERSION, PROJECT_NAME, DEBUG
 
 
 def get_application() -> FastAPI:
-    application = FastAPI(title=PROJECT_NAME, debug=DEBUG, version=VERSION)
+    application = FastAPI(
+        title=PROJECT_NAME,
+        debug=DEBUG,
+        version=VERSION,
+        openapi_url=None,  # Disable the default OpenAPI spec generation
+        docs_url=None,  # Disable the default Swagger UI docs
+        redoc_url=None,  # Disable the default ReDoc UI
+    )
 
     application.add_middleware(
         CORSMiddleware,
@@ -41,3 +49,10 @@ def get_application() -> FastAPI:
 
 app = get_application()
 app.mount("/static", StaticFiles(directory="static"), name="static_files")
+
+
+@app.get("/", include_in_schema=False)
+async def custom_swagger_ui_html():
+    return get_swagger_ui_html(
+        openapi_url="/static/APISpecification.yaml", title="API Docs"
+    )

--- a/app/static/APISpecification.yaml
+++ b/app/static/APISpecification.yaml
@@ -7,9 +7,14 @@ info:
   version: 0.0.1
 servers:
   - url: https://resolver.ensembl.org
+tags:
+  - name: resolver
+    description: Resolver API resolves external urls to Ensembl
 paths:
   /id/{stable_id}:
     get:
+      tags:
+        - resolver
       summary: Resolve stable ID with optional query params
       description: Resolves to a beta url when a stable id wih optional query params provided
       parameters:

--- a/app/static/APISpecification.yaml
+++ b/app/static/APISpecification.yaml
@@ -61,18 +61,24 @@ paths:
                 items:
                   type: object
                   properties:
-                    assembly_name:
-                      type: string
-                      description: Assembly name
-                    accession_id:
-                      type: string
-                      description: Assembly accession id
-                    species_scientific_name:
+                    assembly:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: Assembly name
+                        accession_id:
+                          type: string
+                          description: Assembly accession id
+                    scientific_name:
                       type: string
                       description: Species scientific name
-                    taxonomy_id:
-                      type: integer
-                      description: Taxonomy id
+                    common_name:
+                      type: string
+                      description: Species common name
+                    type:
+                      type: string
+                      description: Genome type
                     resolved_url:
                       type: string
                       description: Resolved url to Ensembl site

--- a/app/static/APISpecification.yaml
+++ b/app/static/APISpecification.yaml
@@ -7,9 +7,6 @@ info:
   version: 0.0.1
 servers:
   - url: https://resolver.ensembl.org
-tags:
-  - name: resolver
-    description: Resolver API resolves external urls to Ensembl
 paths:
   /id/{stable_id}:
     get:
@@ -39,9 +36,9 @@ paths:
           required: false
           schema:
             type: string
-            enum: [genome_browser, entity_viewer]
+            enum: [genome-browser, entity-viewer]
             example:
-              genome_browser
+              genome-browser
         - name: gca
           in: query
           description: GCA assembly accession id of the genome


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2733

This PR makes the home page of resolver (resolver.ensembl.org) show its documentation page

Things to check:
Should the homepage (/) endpoint reside in main.py or should the docs be in its own directory?
APISpec.yaml moved to `static/`. Is this ok?

This PR needs to go in for this to work https://gitlab.ebi.ac.uk/ensembl-web/ensembl_search_hub/-/merge_requests/17