### PR TITLE
resolve rapid species home

### DIFF
--- a/app/api/resources/rapid_view.py
+++ b/app/api/resources/rapid_view.py
@@ -3,7 +3,7 @@ from fastapi.responses import RedirectResponse
 import logging
 from core.logging import InterceptHandler
 from core.config import ENSEMBL_URL
-from api.utils.metadata import get_genome_id_from_accession
+from api.utils.metadata import get_genome_id_from_assembly_accession_id
 
 logging.getLogger().handlers = [InterceptHandler()]
 
@@ -13,11 +13,11 @@ router = APIRouter()
 # Resolve species home
 # https://rapid.ensembl.org/Homo_sapiens_GCA_009914755.4/
 # https://rapid.ensembl.org/Homo_sapiens_GCA_009914755.4/Info/Index
-@router.get("/{species_url}/{subpath:path}", name="Rapid Species Home")
-async def resolve_species(request: Request, species_url: str, subpath: str):
-    (species_name, accession_id) = species_url.split("_GCA_")
+@router.get("/{species_url_name}/{subpath:path}", name="Rapid Species Home")
+async def resolve_species(request: Request, species_url_name: str, subpath: str):
+    _, accession_id = species_url_name.split("_GCA_")
     assembly_accession_id = "GCA_" + accession_id
-    genome_object = get_genome_id_from_accession(assembly_accession_id)
+    genome_object = get_genome_id_from_assembly_accession_id(assembly_accession_id)
     if genome_object:
         genome_id = genome_object.get("genomeUuid")
         url = f"{ENSEMBL_URL}/species/{genome_id}"

--- a/app/api/resources/rapid_view.py
+++ b/app/api/resources/rapid_view.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import RedirectResponse
 import logging
+import re
 from core.logging import InterceptHandler
 from core.config import ENSEMBL_URL
 from api.utils.metadata import get_genome_id_from_assembly_accession_id
@@ -15,13 +16,28 @@ router = APIRouter()
 # https://rapid.ensembl.org/Homo_sapiens_GCA_009914755.4/Info/Index
 @router.get("/{species_url_name}/{subpath:path}", name="Rapid Species Home")
 async def resolve_species(request: Request, species_url_name: str, subpath: str):
-    _, accession_id = species_url_name.split("_GCA_")
+    if re.search("_GCA_", species_url_name):
+        _, accession_id = species_url_name.split("_GCA_")
+    else:
+        logging.error("Genome url name missing GCA assembly accession id")
+        raise HTTPException(
+            status_code=400, detail="Genome url name missing GCA assembly accession id"
+        )
+
     assembly_accession_id = "GCA_" + accession_id
+
+    # RefSeqs have GCF prefix
+    if accession_id.endswith("rs"):
+        accession_id, _ = re.split(r"rs$", accession_id)
+        assembly_accession_id = "GCF_" + accession_id
+
     genome_object = get_genome_id_from_assembly_accession_id(assembly_accession_id)
     if genome_object:
         genome_id = genome_object.get("genomeUuid")
         url = f"{ENSEMBL_URL}/species/{genome_id}"
         return RedirectResponse(url)
+    else:
+        raise HTTPException(status_code=404, detail="Genome not found")
 
 
 @router.get("/", name="Rapid Home")

--- a/app/api/resources/rapid_view.py
+++ b/app/api/resources/rapid_view.py
@@ -19,56 +19,62 @@ router = APIRouter()
 @router.get("/{species_url_name}/{subpath:path}", name="Rapid Species Resources")
 async def resolve_species(
     request: Request, species_url_name: str, subpath: str = "", r: str = Query(None)
-):
+) -> RedirectResponse:
     assembly_accession_id = format_assembly_accession(species_url_name)
 
     if assembly_accession_id is None:
         raise HTTPException(
             status_code=422, detail="Unable to process input accession ID"
         )
+    try:
+        genome_object = get_genome_id_from_assembly_accession_id(assembly_accession_id)
 
-    genome_object = get_genome_id_from_assembly_accession_id(assembly_accession_id)
+        if genome_object and genome_object != {}:
+            genome_id = genome_object["genome_tag"] or genome_object["genome_uuid"]
 
-    if genome_object:
-        genome_id = genome_object["genome_tag"] or genome_object["genome_uuid"]
+            # Extract specific parameters because Ensembl url uses ; instead of &
+            query_string = request.scope["query_string"].decode()
+            query_params = parse_qs(query_string, separator=";")
 
-        # Extract specific parameters because Ensembl url uses ; instead of &
-        query_string = request.scope["query_string"].decode()
-        query_params = parse_qs(query_string, separator=";")
-
-        location = query_params.get("r", [None])[0]
-        gene_id = query_params.get("g", [None])[0]
-
-        if subpath == "" or re.search("Info/Index", subpath, re.IGNORECASE):
-            url = f"{ENSEMBL_URL}/species/{genome_id}"
-        elif re.search("Location", subpath):
-            url = f"{ENSEMBL_URL}/genome-browser/{genome_id}?focus=location:{location}"
-        elif re.search("Gene", subpath):
-            if re.search("Gene/Compara_Homolog", subpath):
-                url = (
-                    f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}"
-                    f"?view=homology"
-                )
-            else:
-                url = f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}"
-
-        elif re.search("Transcript", subpath):
-            if re.search("Domains|ProteinSummary", subpath):
-                url = (
-                    f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}"
-                    f"?view=protein"
-                )
-            else:
-                url = f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}"
+            url = construct_url(genome_id, subpath, query_params)
+            return RedirectResponse(url)
         else:
-            url = ENSEMBL_URL
+            raise HTTPException(status_code=404, detail="Genome not found")
 
-        return RedirectResponse(url)
+    except HTTPException as e:
+        logging.debug(e)
+        raise HTTPException(
+            status_code=e.status_code, detail="Unexpected error occured"
+        )
 
-    else:
-        raise HTTPException(status_code=404, detail="Genome not found")
+    except Exception as e:
+        logging.debug(f"Unexpected error occurred: {e}")
+        raise HTTPException(status_code=500, detail="Unexpected error occurred")
 
 
 @router.get("/", name="Rapid Home")
 async def resolve_home(request: Request):
     return RedirectResponse(ENSEMBL_URL)
+
+
+def construct_url(genome_id, subpath, query_params):
+    location = query_params.get("r", [None])[0]
+    gene_id = query_params.get("g", [None])[0]
+
+    if subpath == "" or re.search("Info/Index", subpath, re.IGNORECASE):
+        return f"{ENSEMBL_URL}/species/{genome_id}"
+    elif re.search("Location", subpath):
+        return f"{ENSEMBL_URL}/genome-browser/{genome_id}?focus=location:{location}"
+    elif re.search("Gene", subpath):
+        if re.search("Gene/Compara_Homolog", subpath):
+            return (
+                f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}?view=homology"
+            )
+        return f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}"
+    elif re.search("Transcript", subpath):
+        if re.search("Domains|ProteinSummary", subpath):
+            return (
+                f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}?view=protein"
+            )
+        return f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}"
+    return ENSEMBL_URL

--- a/app/api/resources/rapid_view.py
+++ b/app/api/resources/rapid_view.py
@@ -20,7 +20,6 @@ router = APIRouter()
 async def resolve_species(
     request: Request, species_url_name: str, subpath: str = "", r: str = Query(None)
 ):
-
     assembly_accession_id = format_assembly_accession(species_url_name)
 
     genome_object = get_genome_id_from_assembly_accession_id(assembly_accession_id)
@@ -36,7 +35,7 @@ async def resolve_species(
         r = query_params.get("r", [None])[0]
         g = query_params.get("g", [None])[0]
 
-        if subpath == "":
+        if subpath == "" or re.search("Info/Index", subpath, re.IGNORECASE):
             url = f"{ENSEMBL_URL}/species/{genome_id}"
         elif re.search("Location", subpath):
             url = f"{ENSEMBL_URL}/genome-browser/{genome_id}?focus=location:{r}"

--- a/app/api/resources/rapid_view.py
+++ b/app/api/resources/rapid_view.py
@@ -13,7 +13,6 @@ router = APIRouter()
 
 
 # Resolve rapid urls
-@router.get("/{species_url_name}", name="Rapid Species Resources")
 @router.get("/{species_url_name}/", name="Rapid Species Resources")
 @router.get("/{species_url_name}/{subpath:path}", name="Rapid Species Resources")
 async def resolve_species(

--- a/app/api/resources/rapid_view.py
+++ b/app/api/resources/rapid_view.py
@@ -4,7 +4,10 @@ import logging
 import re
 from core.logging import InterceptHandler
 from core.config import ENSEMBL_URL
-from api.utils.metadata import get_genome_id_from_assembly_accession_id
+from api.utils.metadata import (
+    get_genome_id_from_assembly_accession_id,
+    get_assembly_accession_from_ncbi,
+)
 
 logging.getLogger().handlers = [InterceptHandler()]
 
@@ -16,8 +19,8 @@ router = APIRouter()
 # https://rapid.ensembl.org/Homo_sapiens_GCA_009914755.4/Info/Index
 @router.get("/{species_url_name}/{subpath:path}", name="Rapid Species Home")
 async def resolve_species(request: Request, species_url_name: str, subpath: str):
-    if re.search("_GCA_", species_url_name):
-        _, accession_id = species_url_name.split("_GCA_")
+    if re.search("_GCA_|_GCF_", species_url_name):
+        _, accession_id = re.split("_GCA_|_GCF_", species_url_name)
     else:
         logging.error("Genome url name missing GCA assembly accession id")
         raise HTTPException(
@@ -26,15 +29,30 @@ async def resolve_species(request: Request, species_url_name: str, subpath: str)
 
     assembly_accession_id = "GCA_" + accession_id
 
-    # RefSeqs have GCF prefix
-    if accession_id.endswith("rs"):
-        accession_id, _ = re.split(r"rs$", accession_id)
-        assembly_accession_id = "GCF_" + accession_id
+    # RefSeqs have GCF prefix but version could be different. So fetch it from ncbi
+    if assembly_accession_id.endswith("rs"):
+        trimmed_assembly_accession_id = re.sub("rs$", "", assembly_accession_id)
+        ncbi_dataset_report = get_assembly_accession_from_ncbi(
+            trimmed_assembly_accession_id
+        )
+
+        if ncbi_dataset_report:
+            assembly_accession_id = ncbi_dataset_report["paired_accession"]
+        else:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Genome not found for accession {assembly_accession_id}",
+            )
 
     genome_object = get_genome_id_from_assembly_accession_id(assembly_accession_id)
+
     if genome_object:
-        genome_id = genome_object.get("genomeUuid")
-        url = f"{ENSEMBL_URL}/species/{genome_id}"
+        genome_id = genome_object["genome_uuid"]
+        genome_tag = genome_object["genome_tag"]
+        if genome_tag:
+            url = f"{ENSEMBL_URL}/species/{genome_tag}"
+        else:
+            url = f"{ENSEMBL_URL}/species/{genome_id}"
         return RedirectResponse(url)
     else:
         raise HTTPException(status_code=404, detail="Genome not found")

--- a/app/api/resources/rapid_view.py
+++ b/app/api/resources/rapid_view.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse
+import logging
+from core.logging import InterceptHandler
+from core.config import ENSEMBL_URL
+from api.utils.metadata import get_genome_id_from_accession
+
+logging.getLogger().handlers = [InterceptHandler()]
+
+router = APIRouter()
+
+
+# Resolve species home
+# https://rapid.ensembl.org/Homo_sapiens_GCA_009914755.4/
+# https://rapid.ensembl.org/Homo_sapiens_GCA_009914755.4/Info/Index
+@router.get("/{species_url}/{subpath:path}", name="Rapid Species Home")
+async def resolve_species(request: Request, species_url: str, subpath: str):
+    (species_name, accession_id) = species_url.split("_GCA_")
+    assembly_accession_id = "GCA_" + accession_id
+    genome_object = get_genome_id_from_accession(assembly_accession_id)
+    if genome_object:
+        genome_id = genome_object.get("genomeUuid")
+        url = f"{ENSEMBL_URL}/species/{genome_id}"
+        return RedirectResponse(url)
+
+
+@router.get("/", name="Rapid Home")
+async def resolve_home(request: Request):
+    return RedirectResponse(ENSEMBL_URL)

--- a/app/api/resources/rapid_view.py
+++ b/app/api/resources/rapid_view.py
@@ -2,11 +2,10 @@ from urllib.parse import parse_qs
 from fastapi import APIRouter, Request, HTTPException, Query
 from fastapi.responses import RedirectResponse
 import logging
-import re
 from core.logging import InterceptHandler
 from core.config import ENSEMBL_URL
 from api.utils.metadata import get_genome_id_from_assembly_accession_id
-from api.utils.rapid import format_assembly_accession
+from api.utils.rapid import construct_url, format_assembly_accession
 
 logging.getLogger().handlers = [InterceptHandler()]
 
@@ -55,26 +54,3 @@ async def resolve_species(
 @router.get("/", name="Rapid Home")
 async def resolve_home(request: Request):
     return RedirectResponse(ENSEMBL_URL)
-
-
-def construct_url(genome_id, subpath, query_params):
-    location = query_params.get("r", [None])[0]
-    gene_id = query_params.get("g", [None])[0]
-
-    if subpath == "" or re.search("Info/Index", subpath, re.IGNORECASE):
-        return f"{ENSEMBL_URL}/species/{genome_id}"
-    elif re.search("Location", subpath):
-        return f"{ENSEMBL_URL}/genome-browser/{genome_id}?focus=location:{location}"
-    elif re.search("Gene", subpath):
-        if re.search("Gene/Compara_Homolog", subpath):
-            return (
-                f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}?view=homology"
-            )
-        return f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}"
-    elif re.search("Transcript", subpath):
-        if re.search("Domains|ProteinSummary", subpath):
-            return (
-                f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}?view=protein"
-            )
-        return f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}"
-    return ENSEMBL_URL

--- a/app/api/resources/routes.py
+++ b/app/api/resources/routes.py
@@ -17,8 +17,9 @@ limitations under the License.
 
 from fastapi import APIRouter
 
-from api.resources import resolver_view
+from api.resources import resolver_view, rapid_view
 
 router = APIRouter()
 
 router.include_router(resolver_view.router, tags=["resolver"], prefix="/id")
+router.include_router(rapid_view.router, tags=["rapid"], prefix="/rapid")

--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -1,7 +1,7 @@
 from loguru import logger
 import requests
 from typing import List
-from core.config import ENSEMBL_URL
+from core.config import ENSEMBL_URL, NCBI_DATASETS_URL
 from api.models.resolver import SearchMatch
 
 
@@ -23,10 +23,10 @@ def get_metadata(matches: List[SearchMatch] = []):
                 )
         except requests.exceptions.HTTPError as HTTPError:
             logger.error(f"HTTPError: {HTTPError}")
-            return None
+            raise HTTPError
         except Exception as e:
             logger.exception(e)
-            return None
+            raise e
 
     return metadata_results
 
@@ -35,15 +35,37 @@ def get_genome_id_from_assembly_accession_id(accession_id: str):
     try:
         session = requests.Session()
         metadata_api_url = (
-            f"{ENSEMBL_URL}/api/metadata/genome?assembly_accession_id={accession_id}"
+            f"{ENSEMBL_URL}/api/metadata/genomeid?assembly_accession_id={accession_id}"
         )
         with session.get(url=metadata_api_url) as response:
             response.raise_for_status()
-            response_json = response.json()
-            return response_json
+            return response.json()
     except requests.exceptions.HTTPError as HTTPError:
         logger.error(f"HTTPError: {HTTPError}")
-        return None
+        raise HTTPError
     except Exception as e:
         logger.exception(e)
-        return None
+        raise e
+
+
+def get_assembly_accession_from_ncbi(accession_id: str):
+    try:
+        session = requests.Session()
+        ncbi_dataset_api_url = (
+            f"{NCBI_DATASETS_URL}/genome/accession/{accession_id}/dataset_report"
+        )
+
+        with session.get(url=ncbi_dataset_api_url) as response:
+            response.raise_for_status()
+            response_json = response.json()
+            if response_json and response_json["reports"]:
+                return response_json["reports"][0]
+            else:
+                return None
+
+    except requests.exceptions.HTTPError as HTTPError:
+        logger.error(f"HTTPError: {HTTPError}")
+        raise HTTPError
+    except Exception as e:
+        logger.exception(e)
+        raise e

--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -29,3 +29,21 @@ def get_metadata(matches: List[SearchMatch] = []):
             return None
 
     return metadata_results
+
+
+def get_genome_id_from_accession(accession_id: str):
+
+    try:
+        session = requests.Session()
+        with session.get(
+            url=f"{ENSEMBL_URL}/api/metadata/genomeid/{accession_id}"
+        ) as response:
+            response.raise_for_status()
+            response_json = response.json()
+            return response_json
+    except requests.exceptions.HTTPError as HTTPError:
+        logger.error(f"HTTPError: {HTTPError}")
+        return None
+    except Exception as e:
+        logger.exception(e)
+        return None

--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -1,7 +1,7 @@
 from loguru import logger
 import requests
 from typing import List
-from core.config import ENSEMBL_URL, NCBI_DATASETS_URL
+from core.config import ENSEMBL_URL
 from api.models.resolver import SearchMatch
 
 
@@ -40,29 +40,6 @@ def get_genome_id_from_assembly_accession_id(accession_id: str):
         with session.get(url=metadata_api_url) as response:
             response.raise_for_status()
             return response.json()
-    except requests.exceptions.HTTPError as HTTPError:
-        logger.error(f"HTTPError: {HTTPError}")
-        raise HTTPError
-    except Exception as e:
-        logger.exception(e)
-        raise e
-
-
-def get_assembly_accession_from_ncbi(accession_id: str):
-    try:
-        session = requests.Session()
-        ncbi_dataset_api_url = (
-            f"{NCBI_DATASETS_URL}/genome/accession/{accession_id}/dataset_report"
-        )
-
-        with session.get(url=ncbi_dataset_api_url) as response:
-            response.raise_for_status()
-            response_json = response.json()
-            if response_json and response_json["reports"]:
-                return response_json["reports"][0]
-            else:
-                return None
-
     except requests.exceptions.HTTPError as HTTPError:
         logger.error(f"HTTPError: {HTTPError}")
         raise HTTPError

--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -31,13 +31,14 @@ def get_metadata(matches: List[SearchMatch] = []):
     return metadata_results
 
 
-def get_genome_id_from_accession(accession_id: str):
+def get_genome_id_from_assembly_accession_id(accession_id: str):
 
     try:
         session = requests.Session()
-        with session.get(
-            url=f"{ENSEMBL_URL}/api/metadata/genomeid/{accession_id}"
-        ) as response:
+        metadata_api_url = (
+            f"{ENSEMBL_URL}/api/metadata/genome?assembly_accession_id={accession_id}"
+        )
+        with session.get(url=metadata_api_url) as response:
             response.raise_for_status()
             response_json = response.json()
             return response_json

--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -32,7 +32,6 @@ def get_metadata(matches: List[SearchMatch] = []):
 
 
 def get_genome_id_from_assembly_accession_id(accession_id: str):
-
     try:
         session = requests.Session()
         metadata_api_url = (

--- a/app/api/utils/rapid.py
+++ b/app/api/utils/rapid.py
@@ -1,6 +1,6 @@
 from loguru import logger
 import requests
-from core.config import NCBI_DATASETS_URL
+from core.config import ENSEMBL_URL, NCBI_DATASETS_URL
 import re
 
 
@@ -52,3 +52,26 @@ def format_assembly_accession(species_url_name: str):
         return assembly_accession_id
     else:
         return None
+
+
+def construct_url(genome_id, subpath, query_params):
+    location = query_params.get("r", [None])[0]
+    gene_id = query_params.get("g", [None])[0]
+
+    if subpath == "" or re.search("Info/Index", subpath, re.IGNORECASE):
+        return f"{ENSEMBL_URL}/species/{genome_id}"
+    elif re.search("Location", subpath):
+        return f"{ENSEMBL_URL}/genome-browser/{genome_id}?focus=location:{location}"
+    elif re.search("Gene", subpath):
+        if re.search("Gene/Compara_Homolog", subpath):
+            return (
+                f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}?view=homology"
+            )
+        return f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}"
+    elif re.search("Transcript", subpath):
+        if re.search("Domains|ProteinSummary", subpath):
+            return (
+                f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}?view=protein"
+            )
+        return f"{ENSEMBL_URL}/entity-viewer/{genome_id}/gene:{gene_id}"
+    return ENSEMBL_URL

--- a/app/api/utils/rapid.py
+++ b/app/api/utils/rapid.py
@@ -1,0 +1,54 @@
+from loguru import logger
+import requests
+from core.config import NCBI_DATASETS_URL
+import re
+
+
+def get_assembly_accession_from_ncbi(accession_id: str):
+    try:
+        session = requests.Session()
+        ncbi_dataset_api_url = (
+            f"{NCBI_DATASETS_URL}/genome/accession/{accession_id}/dataset_report"
+        )
+
+        with session.get(url=ncbi_dataset_api_url) as response:
+            response.raise_for_status()
+            response_json = response.json()
+            if response_json and response_json["reports"]:
+                return response_json["reports"][0]
+            else:
+                return None
+
+    except requests.exceptions.HTTPError as HTTPError:
+        logger.error(f"HTTPError: {HTTPError}")
+        raise HTTPError
+    except Exception as e:
+        logger.exception(e)
+        raise e
+
+
+def format_assembly_accession(species_url_name: str):
+    if re.search("_GCA_|_GCF_", species_url_name):
+        _, accession_id = re.split("_GCA_|_GCF_", species_url_name)
+
+        prefix = "GCA_"
+        if re.search("GCF", species_url_name):
+            prefix = "GCF_"
+
+        assembly_accession_id = prefix + accession_id
+
+        # RefSeqs have GCF prefix but version could be different. So fetch it from ncbi
+        if assembly_accession_id.endswith("rs"):
+            trimmed_assembly_accession_id = re.sub("rs$", "", assembly_accession_id)
+            ncbi_dataset_report = get_assembly_accession_from_ncbi(
+                trimmed_assembly_accession_id
+            )
+
+            if ncbi_dataset_report:
+                assembly_accession_id = ncbi_dataset_report["paired_accession"]
+            else:
+                logger.error("HTTPError: {HTTPError}")
+                return None
+        return assembly_accession_id
+    else:
+        return None

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -36,6 +36,10 @@ ENSEMBL_SEARCH_HUB_API: str = config(
 )
 DEFAULT_APP = config("DEFAULT_APP", cast=str, default="entity-viewer")
 ENSEMBL_URL = config("ENSEMBL_URL", cast=str, default="https://beta.ensembl.org")
+NCBI_DATASETS_URL = config(
+    "NCBI_DATASETS_URL", cast=str, default="https://api.ncbi.nlm.nih.gov/datasets/v2"
+)
+
 DEBUG: bool = config("DEBUG", cast=bool, default=False)
 PROJECT_NAME: str = config("PROJECT_NAME", default="Ensembl Web Resolver")
 ALLOWED_HOSTS: list[str] = config(

--- a/app/tests/test_rapid.py
+++ b/app/tests/test_rapid.py
@@ -32,19 +32,16 @@ class TestRapid(unittest.TestCase):
             "genome2": f"{ENSEMBL_URL}/species/xyz",
         }
 
+    # Test species home page
     @patch("api.resources.rapid_view.get_genome_id_from_assembly_accession_id")
-    @patch("api.resources.rapid_view.format_assembly_accession")
     def test_rapid_species_home_success(
-        self,
-        mock_format_assembly_accession,
-        mock_get_genome_id_from_assembly_accession_id,
+        self, mock_get_genome_id_from_assembly_accession_id
     ):
 
         # test web-metadata-api response without genome_tag
         mock_get_genome_id_from_assembly_accession_id.return_value = (
             self.mock_genome_id_response1
         )
-        mock_format_assembly_accession.return_value = self.mock_ncbi_accession
 
         response = self.client.get(
             f"{self.mock_rapid_api_url}/{self.species_url_name}/",
@@ -72,3 +69,89 @@ class TestRapid(unittest.TestCase):
         self.assertEqual(
             response.headers["location"], self.mock_resolved_url["genome2"]
         )
+
+    # Test Region in detail page
+    @patch("api.resources.rapid_view.get_genome_id_from_assembly_accession_id")
+    def test_rapid_species_location_success(
+        self, mock_get_genome_id_from_assembly_accession_id
+    ):
+
+        # test web-metadata-api response without genome_tag
+        mock_get_genome_id_from_assembly_accession_id.return_value = (
+            self.mock_genome_id_response1
+        )
+
+        response = self.client.get(
+            f"{self.mock_rapid_api_url}/{self.species_url_name}/Location/View",
+            params={"r": "1:1000-2000"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 307)  # Redirect
+        self.assertIn(
+            f"{ENSEMBL_URL}/genome-browser/genome_uuid1?focus=location:1:1000-2000",
+            response.headers["location"],
+        )
+
+    # Test Gene pages
+    @patch("api.resources.rapid_view.get_genome_id_from_assembly_accession_id")
+    def test_rapid_species_gene_compara_homolog(
+        self, mock_get_genome_id_from_assembly_accession_id
+    ):
+        mock_get_genome_id_from_assembly_accession_id.return_value = (
+            self.mock_genome_id_response1
+        )
+
+        response = self.client.get(
+            f"{self.mock_rapid_api_url}/{self.species_url_name}/Gene/Compara_Homolog",
+            params={"g": "GENE123"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 307)  # Redirect
+        self.assertIn(
+            f"{ENSEMBL_URL}/entity-viewer/genome_uuid1/gene:GENE123?view=homology",
+            response.headers["location"],
+        )
+
+    # Test 404
+    @patch("api.resources.rapid_view.get_genome_id_from_assembly_accession_id")
+    def test_rapid_species_404_not_found(
+        self, mock_get_genome_id_from_assembly_accession_id
+    ):
+        mock_get_genome_id_from_assembly_accession_id.return_value = {}
+
+        response = self.client.get(
+            f"{self.mock_rapid_api_url}/{self.species_url_name}/Invalid_GCA"
+        )
+        self.assertEqual(response.status_code, 404)
+
+    # Test invalid url entity
+    def test_rapid_species_422_unprocessable_entity(self):
+        response = self.client.get(f"{self.mock_rapid_api_url}/Invalid_Name/")
+        self.assertEqual(response.status_code, 422)
+
+    # Test POST
+    def test_rapid_species_post_method_not_allowed(self):
+        response = self.client.post(
+            f"{self.mock_rapid_api_url}/{self.species_url_name}/"
+        )
+        self.assertEqual(response.status_code, 405)
+
+    # Test 500
+    @patch("api.resources.rapid_view.get_genome_id_from_assembly_accession_id")
+    def test_rapid_species_500_internal_server_error(
+        self, mock_get_genome_id_from_assembly_accession_id
+    ):
+        mock_get_genome_id_from_assembly_accession_id.return_value = (
+            self.mock_genome_id_response1
+        )
+
+        mock_get_genome_id_from_assembly_accession_id.side_effect = Exception(
+            "Unexpected error"
+        )
+
+        response = self.client.get(
+            f"{self.mock_rapid_api_url}/{self.species_url_name}/"
+        )
+        self.assertEqual(response.status_code, 500)

--- a/app/tests/test_rapid.py
+++ b/app/tests/test_rapid.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from core.config import ENSEMBL_URL
+from main import app
+
+
+class TestRapid(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        self.api_prefix = ""
+        self.mock_rapid_api_url = "/rapid"
+        self.species_url_name = "Human_GCA_123.1"
+        self.species_url_name_refseq = "DogRefSeq_GCA_123.1rs"
+
+        self.mock_genome_id_response1 = {
+            "genome_uuid": "genome_uuid1",
+            "release_version": 110,
+            "genome_tag": "",
+        }
+
+        self.mock_genome_id_response2 = {
+            "genome_uuid": "genome_uuid2",
+            "release_version": 110,
+            "genome_tag": "xyz",
+        }
+
+        self.mock_ncbi_accession = {"paired_accession": "GCF_000001405.40"}
+
+        self.mock_resolved_url = {
+            "genome1": f"{ENSEMBL_URL}/species/genome_uuid1",
+            "genome2": f"{ENSEMBL_URL}/species/xyz",
+        }
+
+    @patch("api.resources.rapid_view.get_genome_id_from_assembly_accession_id")
+    @patch("api.resources.rapid_view.get_assembly_accession_from_ncbi")
+    def test_rapid_species_home_success(
+        self,
+        mock_get_assembly_accession_from_ncbi,
+        mock_get_genome_id_from_assembly_accession_id,
+    ):
+
+        # test web-metadata-api response without genome_tag
+        mock_get_genome_id_from_assembly_accession_id.return_value = (
+            self.mock_genome_id_response1
+        )
+        mock_get_assembly_accession_from_ncbi.return_value = self.mock_ncbi_accession
+
+        response = self.client.get(
+            f"{self.mock_rapid_api_url}/{self.species_url_name}/",
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 307)  # Temporary Redirect
+        self.assertIn("location", response.headers)
+        self.assertEqual(
+            response.headers["location"], self.mock_resolved_url["genome1"]
+        )
+
+        # test web-metadata-api response with genome_tag
+        mock_get_genome_id_from_assembly_accession_id.return_value = (
+            self.mock_genome_id_response2
+        )
+
+        response = self.client.get(
+            f"{self.mock_rapid_api_url}/{self.species_url_name}/",
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 307)  # Temporary Redirect
+        self.assertIn("location", response.headers)
+        self.assertEqual(
+            response.headers["location"], self.mock_resolved_url["genome2"]
+        )

--- a/app/tests/test_rapid.py
+++ b/app/tests/test_rapid.py
@@ -25,7 +25,7 @@ class TestRapid(unittest.TestCase):
             "genome_tag": "xyz",
         }
 
-        self.mock_ncbi_accession = {"paired_accession": "GCF_000001405.40"}
+        self.mock_ncbi_accession = "GCF_000001405.40"
 
         self.mock_resolved_url = {
             "genome1": f"{ENSEMBL_URL}/species/genome_uuid1",
@@ -33,10 +33,10 @@ class TestRapid(unittest.TestCase):
         }
 
     @patch("api.resources.rapid_view.get_genome_id_from_assembly_accession_id")
-    @patch("api.resources.rapid_view.get_assembly_accession_from_ncbi")
+    @patch("api.resources.rapid_view.format_assembly_accession")
     def test_rapid_species_home_success(
         self,
-        mock_get_assembly_accession_from_ncbi,
+        mock_format_assembly_accession,
         mock_get_genome_id_from_assembly_accession_id,
     ):
 
@@ -44,7 +44,7 @@ class TestRapid(unittest.TestCase):
         mock_get_genome_id_from_assembly_accession_id.return_value = (
             self.mock_genome_id_response1
         )
-        mock_get_assembly_accession_from_ncbi.return_value = self.mock_ncbi_accession
+        mock_format_assembly_accession.return_value = self.mock_ncbi_accession
 
         response = self.client.get(
             f"{self.mock_rapid_api_url}/{self.species_url_name}/",

--- a/sample-env
+++ b/sample-env
@@ -3,3 +3,4 @@ ENSEMBL_SEARCH_HUB_API=https://beta.ensembl.org/api/search/stable-id
 DEFAULT_APP=entity-viewer
 ENSEMBL_URL=http://beta.ensembl.org
 DEBUG=true
+NCBI_DATASETS_URL=https://api.ncbi.nlm.nih.gov/datasets/v2


### PR DESCRIPTION
This PR is to resolve rapid species home urls. 

https://rapid.ensembl.org/Homo_sapiens_GCA_009914755.4/
https://rapid.ensembl.org/Homo_sapiens_GCA_009914755.4/Info/Index
Also it would redirect rapid home page to beta home - something to decide whether to do it or not.

Uses new grpc endpoint in web-metadata-api  https://github.com/Ensembl/ensembl-web-metadata-api/pull/63

https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2830

Also added tests

Example redirects:

http://resolve-species-home.review.ensembl.org/rapid/Chorisops_tibialis_GCA_963669355.1/
http://resolve-species-home.review.ensembl.org/rapid/Chorisops_tibialis_GCA_963669355.1/Info/Index/

Region in detail:
http://resolve-species-home.review.ensembl.org/rapid/Agrilus_biguttatus_GCA_963921985.1/Location/View?r=10:10920098-10971228

Gene Summary:
http://resolve-species-home.review.ensembl.org/rapid/Chorisops_tibialis_GCA_963669355.1/Gene/Summary?g=BRAKERXYFG00000002445;r=1:317198833-317350935

Homology:
http://resolve-species-home.review.ensembl.org/rapid/Dichetophora_obliterata_GCA_963920525.1/Gene/Compara_Homolog?g=ENSEQNG00000006211;r=2:233069390-233130546

Protein domains
http://resolve-species-home.review.ensembl.org/rapid/Agrilus_biguttatus_GCA_963921985.1/Transcript/ProteinSummary?db=core;g=ENSRZDG00005003824;r=10:10920098-10971228;t=ENSRZDT00005006367