### PR TITLE
Handle no accept header in the request issue

### DIFF
--- a/app/api/utils/commons.py
+++ b/app/api/utils/commons.py
@@ -32,4 +32,4 @@ def build_genome_browser_url(genome_id: str, stable_id: str) -> str:
 
 
 def is_json_request(request) -> bool:
-    return "application/json" in request.headers.get("accept")
+    return "application/json" in request.headers.get("accept", "")


### PR DESCRIPTION
This PR fixes issue when we get requests without any `accept` header. 

Error in prod
```
2025-09-19 10:33:13.983 | INFO     | logging:callHandlers:1706 - 10.251.245.102:33020 - "GET /rapid/id/GeneID_123505981 HTTP/1.1" 500                                                                                                                                                      
ERROR:    Exception in ASGI application                                                                                                                                                                                                                                                    
Traceback (most recent call last):                                                                                                                                                                                                                                                         
  File "/app/api/resources/rapid_view.py", line 56, in resolve_rapid_stable_id                                                                                                                                                                                                             
    if is_json_request(request):                                                                                                                                                                                                                                                           
       ^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                            
  File "/app/api/utils/commons.py", line 35, in is_json_request                                                                                                                                                                                                                            
    return "application/json" in request.headers.get("accept")                                                                                                                                                                                                                             
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                             
TypeError: argument of type 'NoneType' is not iterable                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                           
During handling of the above exception, another exception occurred:
  File "/app/api/resources/rapid_view.py", line 62, in resolve_rapid_stable_id                                                                                                                                                                                                             
    if is_json_request(request):                                                                                                                                                                                                                                                           
       ^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                            
  File "/app/api/utils/commons.py", line 35, in is_json_request                                                                                                                                                                                                                            
    return "application/json" in request.headers.get("accept")                                                                                                                                                                                                                             
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                             
TypeError: argument of type 'NoneType' is not iterable
```

Reproduced in local
curl -v -H "Accept:" http://127.0.0.1:8001/rapid/id/XM_027192776.1

Error
```
  File "/Users/shabr/PythonProjects/ensembl-web-resolver/app/api/resources/rapid_view.py", line 33, in resolve_rapid_stable_id
    if is_json_request(request):
       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shabr/PythonProjects/ensembl-web-resolver/app/api/utils/commons.py", line 35, in is_json_request
    return "application/json" in request.headers.get("accept")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

After fix we should get resolver html error page
