### PR TITLE
Change 'species' to 'genome' in resolved urls

### DIFF
--- a/app/api/resources/legacy_url_resolver_view.py
+++ b/app/api/resources/legacy_url_resolver_view.py
@@ -122,7 +122,7 @@ def _url_resolver_interstitial_response(url: str):
     response = UrlResolverResponse(
         source_url=url,
         archive_url=archive_url,
-        new_ensembl_url=f"{ENSEMBL_URL}/species-selector",
+        new_ensembl_url=f"{ENSEMBL_URL}/genome-selector",
         code=404,
         message="This page could not be resolved on the new Ensembl website.",
     )

--- a/app/api/resources/rapid_view.py
+++ b/app/api/resources/rapid_view.py
@@ -118,7 +118,7 @@ async def resolve_species(
             input_error_response = RapidResolverResponse(
                 response_type=RapidResolverHtmlResponseType.ERROR,
                 code=422,
-                resolved_url=f"{ENSEMBL_URL}/species-selector",
+                resolved_url=f"{ENSEMBL_URL}/genome-selector",
                 message="Invalid input accession ID",
                 species_name=species_url_name,
                 rapid_archive_url=rapid_archive_url
@@ -152,7 +152,7 @@ async def resolve_species(
         response = RapidResolverResponse(
             response_type=RapidResolverHtmlResponseType.ERROR,
             code=e.status_code,
-            resolved_url=f"{ENSEMBL_URL}/species-selector",
+            resolved_url=f"{ENSEMBL_URL}/genome-selector",
             message=e.detail,
             species_name=species_url_name,
             rapid_archive_url=rapid_archive_url
@@ -164,7 +164,7 @@ async def resolve_species(
             species_name=species_url_name,
             response_type=RapidResolverHtmlResponseType.ERROR,
             code=500,
-            resolved_url=f"{ENSEMBL_URL}/species-selector",
+            resolved_url=f"{ENSEMBL_URL}/genome-selector",
             message=str(e),
             rapid_archive_url=rapid_archive_url
         )

--- a/app/api/resources/templates/shared/id_content.html
+++ b/app/api/resources/templates/shared/id_content.html
@@ -10,7 +10,7 @@
             <div class="error-message">
                 {{ response.message }}
             </div>
-            {{ url_helper.render_url("Go to", "https://beta.ensembl.org/species-selector") }}
+            {{ url_helper.render_url("Go to", "https://beta.ensembl.org/genome-selector") }}
         {% else %}
             {% for item in response.content %}
                 <div class="genome-detail-container"

--- a/app/api/utils/legacy_url_resolver.py
+++ b/app/api/utils/legacy_url_resolver.py
@@ -86,16 +86,16 @@ def _quote_url_part(value) -> str:
 
 
 def _build_species_url(genome_uuid: str, query_params: dict[str, list[str]]) -> str:
-    """Build a new Ensembl species page URL.
+    """Build a new Ensembl genome page URL.
 
     Args:
         genome_uuid: new Ensembl genome UUID from the species mapping table.
         query_params: Parsed legacy query parameters. Unused for this rule.
 
     Returns:
-        The resolved new Ensembl species URL.
+        The resolved new Ensembl genome page URL.
     """
-    return f"{ENSEMBL_URL}/species/{_quote_url_part(genome_uuid)}"
+    return f"{ENSEMBL_URL}/genome/{_quote_url_part(genome_uuid)}"
 
 
 def _build_location_url(genome_uuid: str, query_params: dict[str, list[str]]) -> str:

--- a/app/api/utils/rapid.py
+++ b/app/api/utils/rapid.py
@@ -65,11 +65,11 @@ def construct_url(genome_id, subpath, query_params):
         return ENSEMBL_URL
 
     if not subpath or "info/index" in subpath_lower:
-        return f"{ENSEMBL_URL}/species/{genome_id}"
+        return f"{ENSEMBL_URL}/genome/{genome_id}"
 
     if "location" in subpath_lower:
         if "genome" in subpath_lower:
-            return f"{ENSEMBL_URL}/species/{genome_id}"
+            return f"{ENSEMBL_URL}/genome/{genome_id}"
         if location is None:
             raise ValueError("Location paramater 'r' is missing for Location view")
         return f"{ENSEMBL_URL}/genome-browser/{genome_id}?focus=location:{location}"

--- a/tests/test_legacy_url_resolver.py
+++ b/tests/test_legacy_url_resolver.py
@@ -21,7 +21,7 @@ class TestUrlResolver(unittest.TestCase):
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_species_home_with_json_response(self, mock_species_lookup):
-        """Resolve a species home URL to the new Ensembl species page."""
+        """Resolve a species home URL to the new Ensembl genome page."""
         mock_species_lookup.return_value = self.genome_uuid
 
         response = self.client.get(
@@ -34,7 +34,7 @@ class TestUrlResolver(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            {"resolved_url": f"{ENSEMBL_URL}/species/{self.genome_uuid}"},
+            {"resolved_url": f"{ENSEMBL_URL}/genome/{self.genome_uuid}"},
         )
         mock_species_lookup.assert_called_once_with("Homo_sapiens")
 
@@ -52,7 +52,7 @@ class TestUrlResolver(unittest.TestCase):
         self.assertEqual(response.status_code, 308)
         self.assertEqual(
             response.headers["location"],
-            f"{ENSEMBL_URL}/species/{self.genome_uuid}",
+            f"{ENSEMBL_URL}/genome/{self.genome_uuid}",
         )
         mock_species_lookup.assert_called_once_with("Crocodylus_porosus")
 
@@ -448,7 +448,7 @@ class TestUrlResolver(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
         self.assertNotIn("location", response.headers)
         self.assertIn("This page could not be resolved", response.text)
-        self.assertIn(f"{ENSEMBL_URL}/species-selector", response.text)
+        self.assertIn(f"{ENSEMBL_URL}/genome-selector", response.text)
         self.assertIn("https://jun2026.archive.ensembl.org/foo", response.text)
         self.assertIn(f"{STATIC_PATH}/css/styles.css", response.text)
         mock_species_lookup.assert_called_once_with("foo")

--- a/tests/test_rapid.py
+++ b/tests/test_rapid.py
@@ -31,8 +31,8 @@ class TestRapid(unittest.TestCase):
         self.mock_ncbi_accession = "GCF_000001405.40"
 
         self.mock_resolved_url = {
-            "genome1": f"{ENSEMBL_URL}/species/genome_uuid1",
-            "genome2": f"{ENSEMBL_URL}/species/xyz",
+            "genome1": f"{ENSEMBL_URL}/genome/genome_uuid1",
+            "genome2": f"{ENSEMBL_URL}/genome/xyz",
         }
     
     # Test rapid home page


### PR DESCRIPTION
This is part of the renaming of:
- species selector to genome selector
- species page to genome page

Related PR in ensembl-client: https://github.com/Ensembl/ensembl-client/pull/1324

Related Jira ticket: https://embl.atlassian.net/browse/ENSWBSITES-3009

================

Something not directly related to this PR, but worth pointing out, is that we have multiple places in the code where the domain name `beta.ensembl.org` has been hard-coded. We should remember to change that during the beta migration.