### PR TITLE
Use assembly accession instead of genome UUID in resolved URLs

### DIFF
--- a/app/api/resources/legacy_url_resolver_view.py
+++ b/app/api/resources/legacy_url_resolver_view.py
@@ -6,6 +6,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from app.api.error_response import response_error_handler
 from app.api.models.resolver import UrlResolverResponse
 from app.api.utils.commons import is_json_request
+from app.api.utils.metadata import get_assembly_accession_id_from_genome_id
 from app.api.utils.species_mapping import (
     SpeciesMappingNotFoundError,
     SpeciesMappingConfigurationError,
@@ -47,6 +48,7 @@ async def resolve_url(request: Request, url: str):
         resolved_url = resolve_legacy_ensembl_url(
             url,
             get_genome_uuid_from_species_url,
+            get_assembly_accession_id_from_genome_id,
             get_static_legacy_url_mapping,
         )
         response = UrlResolverResponse(resolved_url=resolved_url)

--- a/app/api/utils/legacy_url_resolver.py
+++ b/app/api/utils/legacy_url_resolver.py
@@ -91,24 +91,24 @@ def _quote_url_part(value) -> str:
     return quote(str(value), safe="")
 
 
-def _build_species_url(genome_uuid: str, query_params: dict[str, list[str]]) -> str:
+def _build_species_url(genome_id: str, query_params: dict[str, list[str]]) -> str:
     """Build a new Ensembl genome page URL.
 
     Args:
-        genome_uuid: new Ensembl genome UUID from the species mapping table.
+        genome_id: New Ensembl target genome identifier.
         query_params: Parsed legacy query parameters. Unused for this rule.
 
     Returns:
         The resolved new Ensembl genome page URL.
     """
-    return f"{ENSEMBL_URL}/genome/{_quote_url_part(genome_uuid)}"
+    return f"{ENSEMBL_URL}/genome/{_quote_url_part(genome_id)}"
 
 
-def _build_location_url(genome_uuid: str, query_params: dict[str, list[str]]) -> str:
+def _build_location_url(genome_id: str, query_params: dict[str, list[str]]) -> str:
     """Build a new Ensembl genome browser URL focused on a genomic location.
 
     Args:
-        genome_uuid: new Ensembl genome UUID from the species mapping table.
+        genome_id: New Ensembl target genome identifier.
         query_params: Parsed legacy query parameters containing ``r``.
 
     Returns:
@@ -117,18 +117,18 @@ def _build_location_url(genome_uuid: str, query_params: dict[str, list[str]]) ->
     location = _require_query_value(query_params, "r")
     encoded_location = quote(location, safe=":-")
     return (
-        f"{ENSEMBL_URL}/genome-browser/{_quote_url_part(genome_uuid)}"
+        f"{ENSEMBL_URL}/genome-browser/{_quote_url_part(genome_id)}"
         f"?focus=location:{encoded_location}&location={encoded_location}"
     )
 
 
 def _build_gene_browser_url(
-    genome_uuid: str, query_params: dict[str, list[str]]
+    genome_id: str, query_params: dict[str, list[str]]
 ) -> str:
     """Build a new Ensembl genome browser URL focused on a gene.
 
     Args:
-        genome_uuid: new Ensembl genome UUID from the species mapping table.
+        genome_id: New Ensembl target genome identifier.
         query_params: Parsed legacy query parameters containing ``g``.
 
     Returns:
@@ -136,18 +136,18 @@ def _build_gene_browser_url(
     """
     gene_id = _require_query_value(query_params, "g")
     return (
-        f"{ENSEMBL_URL}/genome-browser/{_quote_url_part(genome_uuid)}"
+        f"{ENSEMBL_URL}/genome-browser/{_quote_url_part(genome_id)}"
         f"?focus=gene:{_quote_url_part(gene_id)}"
     )
 
 
 def _build_transcript_browser_url(
-    genome_uuid: str, query_params: dict[str, list[str]]
+    genome_id: str, query_params: dict[str, list[str]]
 ) -> str:
     """Build a new Ensembl genome browser URL focused on a transcript.
 
     Args:
-        genome_uuid: new Ensembl genome UUID from the species mapping table.
+        genome_id: New Ensembl target genome identifier.
         query_params: Parsed legacy query parameters containing ``t``.
 
     Returns:
@@ -155,18 +155,18 @@ def _build_transcript_browser_url(
     """
     transcript_id = _require_query_value(query_params, "t")
     return (
-        f"{ENSEMBL_URL}/genome-browser/{_quote_url_part(genome_uuid)}"
+        f"{ENSEMBL_URL}/genome-browser/{_quote_url_part(genome_id)}"
         f"?focus=transcript:{_quote_url_part(transcript_id)}"
     )
 
 
 def _build_gene_feature_explorer_url(
-    genome_uuid: str, query_params: dict[str, list[str]]
+    genome_id: str, query_params: dict[str, list[str]]
 ) -> str:
     """Build a new Ensembl feature explorer URL for a gene.
 
     Args:
-        genome_uuid: new Ensembl genome UUID from the species mapping table.
+        genome_id: New Ensembl target genome identifier.
         query_params: Parsed legacy query parameters containing ``g``.
 
     Returns:
@@ -174,33 +174,33 @@ def _build_gene_feature_explorer_url(
     """
     gene_id = _require_query_value(query_params, "g")
     return (
-        f"{ENSEMBL_URL}/feature-explorer/{_quote_url_part(genome_uuid)}"
+        f"{ENSEMBL_URL}/feature-explorer/{_quote_url_part(genome_id)}"
         f"/gene:{_quote_url_part(gene_id)}"
     )
 
 
 def _build_gene_homology_url(
-    genome_uuid: str, query_params: dict[str, list[str]]
+    genome_id: str, query_params: dict[str, list[str]]
 ) -> str:
     """Build a new Ensembl feature explorer URL with the homology view selected.
 
     Args:
-        genome_uuid: new Ensembl genome UUID from the species mapping table.
+        genome_id: New Ensembl target genome identifier.
         query_params: Parsed legacy query parameters containing ``g``.
 
     Returns:
         The resolved new Ensembl feature explorer homology URL.
     """
-    return f"{_build_gene_feature_explorer_url(genome_uuid, query_params)}?view=homology"
+    return f"{_build_gene_feature_explorer_url(genome_id, query_params)}?view=homology"
 
 
 def _build_transcript_feature_explorer_url(
-    genome_uuid: str, query_params: dict[str, list[str]]
+    genome_id: str, query_params: dict[str, list[str]]
 ) -> str:
     """Build a new Ensembl feature explorer URL for a transcript.
 
     Args:
-        genome_uuid: new Ensembl genome UUID from the species mapping table.
+        genome_id: New Ensembl target genome identifier.
         query_params: Parsed legacy query parameters containing ``t``.
 
     Returns:
@@ -208,25 +208,25 @@ def _build_transcript_feature_explorer_url(
     """
     transcript_id = _require_query_value(query_params, "t")
     return (
-        f"{ENSEMBL_URL}/feature-explorer/{_quote_url_part(genome_uuid)}"
+        f"{ENSEMBL_URL}/feature-explorer/{_quote_url_part(genome_id)}"
         f"/transcript:{_quote_url_part(transcript_id)}"
     )
 
 
 def _build_transcript_protein_url(
-    genome_uuid: str, query_params: dict[str, list[str]]
+    genome_id: str, query_params: dict[str, list[str]]
 ) -> str:
     """Build a new Ensembl feature explorer URL with the protein view selected.
 
     Args:
-        genome_uuid: new Ensembl genome UUID from the species mapping table.
+        genome_id: New Ensembl target genome identifier.
         query_params: Parsed legacy query parameters containing ``t``.
 
     Returns:
         The resolved new Ensembl transcript URL with the protein view selected.
     """
     return (
-        f"{_build_transcript_feature_explorer_url(genome_uuid, query_params)}"
+        f"{_build_transcript_feature_explorer_url(genome_id, query_params)}"
         "?view=protein"
     )
 
@@ -401,6 +401,7 @@ def _find_species_rule(
 def resolve_legacy_ensembl_url(
     legacy_url: str,
     species_to_genome_uuid: Callable[[str], str],
+    genome_uuid_to_accession_id: Callable[[str], str | None],
     static_legacy_url_mapping: Callable[[str], str | None] | None = None,
 ) -> str:
     """Resolve a supported legacy Ensembl URL to its new Ensembl equivalent.
@@ -409,6 +410,8 @@ def resolve_legacy_ensembl_url(
         legacy_url: Full legacy URL or path submitted by the caller.
         species_to_genome_uuid: Function that maps legacy species URL names to
             new Ensembl genome UUIDs.
+        genome_uuid_to_accession_id: Function that maps current Ensembl genome
+            UUIDs to assembly accession IDs when available.
         static_legacy_url_mapping: Optional function that maps configured legacy
             hosts or paths directly to their new Ensembl URLs.
 
@@ -453,18 +456,18 @@ def resolve_legacy_ensembl_url(
     species_url = path_segments[0]
     legacy_path = path_segments[1:]
 
-    if not legacy_path:
-        genome_uuid = species_to_genome_uuid(species_url)
-        return _build_species_url(genome_uuid, query_params)
-
-    # Species-scoped legacy pages resolve through the rule table. Unsupported
-    # shapes fail explicitly so we do not produce misleading redirects.
-    rule = _find_species_rule(legacy_path, query_params)
-
-    if rule is None:
-        raise UnsupportedLegacyUrlError(
-            "No supported new Ensembl equivalent for this URL"
-        )
+    if legacy_path:
+        # Species-scoped legacy pages resolve through the rule table. Unsupported
+        # shapes fail explicitly so we do not produce misleading redirects.
+        rule = _find_species_rule(legacy_path, query_params)
+        if rule is None:
+            raise UnsupportedLegacyUrlError(
+                "No supported new Ensembl equivalent for this URL"
+            )
+        build_url = rule.build_url
+    else:
+        build_url = _build_species_url
 
     genome_uuid = species_to_genome_uuid(species_url)
-    return rule.build_url(genome_uuid, query_params)
+    target_genome_id = genome_uuid_to_accession_id(genome_uuid) or genome_uuid
+    return build_url(target_genome_id, query_params)

--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -43,3 +43,31 @@ def get_genome_id_from_assembly_accession_id(accession_id: str):
         raise Exception(
             f"Failed to fetch genome ID for assembly accession '{accession_id}': {e}"
         ) from e
+
+
+def get_assembly_accession_id_from_genome_id(genome_id: str) -> str | None:
+    """Fetch the assembly accession ID for a current Ensembl genome ID.
+
+    Args:
+        genome_id: Current Ensembl genome UUID.
+
+    Returns:
+        The assembly accession ID, or ``None`` when the genome has no accession.
+
+    Raises:
+        Exception: If the metadata explain endpoint cannot be queried or decoded.
+    """
+    try:
+        session = requests.Session()
+        metadata_api_url = f"{ENSEMBL_URL}/api/metadata/genome/{genome_id}/explain"
+        with session.get(url=metadata_api_url, timeout=10) as response:
+            response.raise_for_status()
+            payload = response.json()
+
+        assembly = payload.get("assembly") if isinstance(payload, dict) else None
+        accession_id = assembly.get("accession_id") if isinstance(assembly, dict) else None
+        return accession_id or None
+    except Exception as error:
+        raise Exception(
+            f"Failed to fetch assembly accession for genome '{genome_id}': {error}"
+        ) from error

--- a/tests/test_legacy_url_resolver.py
+++ b/tests/test_legacy_url_resolver.py
@@ -19,14 +19,24 @@ class TestUrlResolver(unittest.TestCase):
         api_prefix = "" if APP_PREFIX == "/" else APP_PREFIX
         self.mock_url_resolver_api_url = f"{api_prefix}/legacy"
         self.genome_uuid = "genome_uuid1"
+        self.assembly_accession_id = "GCA_01234567.1"
         self.static_mapping_patcher = patch(
             "app.api.resources.legacy_url_resolver_view.get_static_legacy_url_mapping"
         )
         self.mock_static_mapping = self.static_mapping_patcher.start()
         self.mock_static_mapping.return_value = None
+        self.assembly_accession_patcher = patch(
+            "app.api.resources.legacy_url_resolver_view."
+            "get_assembly_accession_id_from_genome_id"
+        )
+        self.mock_assembly_accession_lookup = (
+            self.assembly_accession_patcher.start()
+        )
+        self.mock_assembly_accession_lookup.return_value = self.assembly_accession_id
 
     def tearDown(self):
         self.static_mapping_patcher.stop()
+        self.assembly_accession_patcher.stop()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_static_path_mapping_with_redirect(self, mock_species_lookup):
@@ -55,6 +65,7 @@ class TestUrlResolver(unittest.TestCase):
             "https://staging-plants.ensembl.org/Multi/Tools/Blast/?discard=this"
         )
         mock_species_lookup.assert_not_called()
+        self.mock_assembly_accession_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_static_host_mapping_with_json_response(self, mock_species_lookup):
@@ -75,6 +86,7 @@ class TestUrlResolver(unittest.TestCase):
         )
         self.mock_static_mapping.assert_called_once_with("staging-protists.ensembl.org")
         mock_species_lookup.assert_not_called()
+        self.mock_assembly_accession_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_info_paths_to_archive_hosts(self, mock_species_lookup):
@@ -122,6 +134,7 @@ class TestUrlResolver(unittest.TestCase):
                 self.assertEqual(response.json(), {"resolved_url": expected_url})
                 self.mock_static_mapping.assert_not_called()
                 mock_species_lookup.assert_not_called()
+                self.mock_assembly_accession_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_info_archive_preserves_query_and_fragment(
@@ -149,6 +162,7 @@ class TestUrlResolver(unittest.TestCase):
         )
         self.mock_static_mapping.assert_not_called()
         mock_species_lookup.assert_not_called()
+        self.mock_assembly_accession_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_info_unknown_host_does_not_redirect(self, mock_species_lookup):
@@ -164,6 +178,7 @@ class TestUrlResolver(unittest.TestCase):
         self.assertNotIn("location", response.headers)
         self.mock_static_mapping.assert_not_called()
         mock_species_lookup.assert_not_called()
+        self.mock_assembly_accession_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_species_home_with_json_response(self, mock_species_lookup):
@@ -180,9 +195,10 @@ class TestUrlResolver(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            {"resolved_url": f"{ENSEMBL_URL}/genome/{self.genome_uuid}"},
+            {"resolved_url": f"{ENSEMBL_URL}/genome/{self.assembly_accession_id}"},
         )
         mock_species_lookup.assert_called_once_with("Homo_sapiens")
+        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_bare_species_path_with_redirect(self, mock_species_lookup):
@@ -198,9 +214,10 @@ class TestUrlResolver(unittest.TestCase):
         self.assertEqual(response.status_code, 308)
         self.assertEqual(
             response.headers["location"],
-            f"{ENSEMBL_URL}/genome/{self.genome_uuid}",
+            f"{ENSEMBL_URL}/genome/{self.assembly_accession_id}",
         )
         mock_species_lookup.assert_called_once_with("Crocodylus_porosus")
+        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_bare_species_path_without_uuid_redirects_to_archive(
@@ -242,14 +259,17 @@ class TestUrlResolver(unittest.TestCase):
         self.assertEqual(
             response.headers["location"],
             (
-                f"{ENSEMBL_URL}/feature-explorer/{self.genome_uuid}"
+                f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
                 "/gene:ENSG00000012048"
             ),
         )
+        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
-    def test_resolve_gene_summary_with_uuid_lookup_value(self, mock_species_lookup):
-        """Resolve URLs when DuckDB returns genome UUID as a UUID object."""
+    def test_resolve_gene_summary_uses_accession_for_uuid_lookup_value(
+        self, mock_species_lookup
+    ):
+        """Pass mapped UUIDs to metadata and use the returned accession."""
         genome_uuid = UUID("12345678-1234-5678-1234-567812345678")
         mock_species_lookup.return_value = genome_uuid
 
@@ -270,11 +290,70 @@ class TestUrlResolver(unittest.TestCase):
             response.json(),
             {
                 "resolved_url": (
-                    f"{ENSEMBL_URL}/feature-explorer/{genome_uuid}"
+                    f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
                     "/gene:ENSG00000012048"
                 )
             },
         )
+        self.mock_assembly_accession_lookup.assert_called_once_with(genome_uuid)
+
+    @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
+    def test_resolve_gene_summary_without_accession_uses_genome_uuid(
+        self, mock_species_lookup
+    ):
+        """Retain the current genome UUID when metadata has no accession."""
+        mock_species_lookup.return_value = self.genome_uuid
+        self.mock_assembly_accession_lookup.return_value = None
+
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={
+                "url": (
+                    "https://www.ensembl.org/Homo_sapiens/Gene/Summary"
+                    "?g=ENSG00000012048"
+                )
+            },
+            headers={"accept": "application/json"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "resolved_url": (
+                    f"{ENSEMBL_URL}/feature-explorer/{self.genome_uuid}"
+                    "/gene:ENSG00000012048"
+                )
+            },
+        )
+        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
+
+    @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
+    def test_resolve_gene_summary_returns_500_for_accession_lookup_failure(
+        self, mock_species_lookup
+    ):
+        """Return an error when the explain endpoint cannot be queried."""
+        mock_species_lookup.return_value = self.genome_uuid
+        self.mock_assembly_accession_lookup.side_effect = Exception(
+            "Failed to fetch assembly accession for genome 'genome_uuid1': 503 Server Error"
+        )
+
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={
+                "url": (
+                    "https://www.ensembl.org/Homo_sapiens/Gene/Summary"
+                    "?g=ENSG00000012048"
+                )
+            },
+            headers={"accept": "application/json"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("Failed to fetch assembly accession", response.text)
+        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_location_view_with_semicolon_query(self, mock_species_lookup):
@@ -298,7 +377,7 @@ class TestUrlResolver(unittest.TestCase):
             response.json(),
             {
                 "resolved_url": (
-                    f"{ENSEMBL_URL}/genome-browser/{self.genome_uuid}"
+                    f"{ENSEMBL_URL}/genome-browser/{self.assembly_accession_id}"
                     "?focus=location:17:38449840-38530994"
                     "&location=17:38449840-38530994"
                 )
@@ -327,7 +406,7 @@ class TestUrlResolver(unittest.TestCase):
             response.json(),
             {
                 "resolved_url": (
-                    f"{ENSEMBL_URL}/genome-browser/{self.genome_uuid}"
+                    f"{ENSEMBL_URL}/genome-browser/{self.assembly_accession_id}"
                     "?focus=transcript:ENST00000357654"
                 )
             },
@@ -357,7 +436,7 @@ class TestUrlResolver(unittest.TestCase):
                     response.json(),
                     {
                         "resolved_url": (
-                            f"{ENSEMBL_URL}/feature-explorer/{self.genome_uuid}"
+                            f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
                             "/gene:ENSG00000012048"
                         )
                     },
@@ -385,7 +464,7 @@ class TestUrlResolver(unittest.TestCase):
             response.json(),
             {
                 "resolved_url": (
-                    f"{ENSEMBL_URL}/feature-explorer/{self.genome_uuid}"
+                    f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
                     "/transcript:ENST00000357654"
                 )
             },
@@ -413,7 +492,7 @@ class TestUrlResolver(unittest.TestCase):
             response.json(),
             {
                 "resolved_url": (
-                    f"{ENSEMBL_URL}/feature-explorer/{self.genome_uuid}"
+                    f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
                     "/transcript:ENST00000357654"
                 )
             },
@@ -452,6 +531,7 @@ class TestUrlResolver(unittest.TestCase):
 
         self.assertEqual(response.status_code, 404)
         mock_species_lookup.assert_not_called()
+        self.mock_assembly_accession_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_missing_species_redirects_to_main_archive(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.api.utils.metadata import get_assembly_accession_id_from_genome_id
+from app.core.config import ENSEMBL_URL
+
+
+class TestMetadata(unittest.TestCase):
+    @patch("app.api.utils.metadata.requests.Session")
+    def test_get_assembly_accession_id_from_genome_id(self, mock_session_class):
+        genome_id = "genome_uuid1"
+        response = MagicMock()
+        response.json.return_value = {"assembly": {"accession_id": "GCA_01234567.1"}}
+        session = mock_session_class.return_value
+        session.get.return_value.__enter__.return_value = response
+
+        accession_id = get_assembly_accession_id_from_genome_id(genome_id)
+
+        self.assertEqual(accession_id, "GCA_01234567.1")
+        session.get.assert_called_once_with(
+            url=f"{ENSEMBL_URL}/api/metadata/genome/{genome_id}/explain",
+            timeout=10,
+        )
+        response.raise_for_status.assert_called_once_with()
+
+    @patch("app.api.utils.metadata.requests.Session")
+    def test_get_assembly_accession_id_returns_none_when_accession_is_absent(
+        self, mock_session_class
+    ):
+        response = MagicMock()
+        response.json.return_value = {"assembly": {}}
+        mock_session_class.return_value.get.return_value.__enter__.return_value = response
+
+        accession_id = get_assembly_accession_id_from_genome_id("genome_uuid1")
+
+        self.assertIsNone(accession_id)
+
+    @patch("app.api.utils.metadata.requests.Session")
+    def test_get_assembly_accession_id_wraps_endpoint_errors(self, mock_session_class):
+        response = MagicMock()
+        response.raise_for_status.side_effect = Exception("503 Server Error")
+        mock_session_class.return_value.get.return_value.__enter__.return_value = response
+
+        with self.assertRaisesRegex(
+            Exception,
+            "Failed to fetch assembly accession for genome 'genome_uuid1': 503 Server Error",
+        ):
+            get_assembly_accession_id_from_genome_id("genome_uuid1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR updates legacy URL routing to use assembly accession IDs instead of  genome UUIDs in the resolved URLs.
It uses metadata explain endpoint for genome ID => accession mapping. Uses genome UUID as fallback when no matching accession is found (but still surfaces metadata errors as 503 response).