### PR TITLE
Handle variation urls

### DIFF
--- a/app/api/resources/legacy_url_resolver_view.py
+++ b/app/api/resources/legacy_url_resolver_view.py
@@ -6,7 +6,10 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from app.api.error_response import response_error_handler
 from app.api.models.resolver import UrlResolverResponse
 from app.api.utils.commons import is_json_request
-from app.api.utils.metadata import get_assembly_accession_id_from_genome_id
+from app.api.utils.metadata import (
+    get_assembly_accession_id_from_genome_id,
+    search_variant,
+)
 from app.api.utils.species_mapping import (
     SpeciesMappingNotFoundError,
     SpeciesMappingConfigurationError,
@@ -49,6 +52,7 @@ async def resolve_url(request: Request, url: str):
             url,
             get_genome_uuid_from_species_url,
             get_assembly_accession_id_from_genome_id,
+            search_variant,
             get_static_legacy_url_mapping,
         )
         response = UrlResolverResponse(resolved_url=resolved_url)

--- a/app/api/utils/legacy_url_resolver.py
+++ b/app/api/utils/legacy_url_resolver.py
@@ -256,7 +256,7 @@ def _resolve_variant_url(
     genome_uuid: str,
     variant_id: str,
     variant_search: Callable[[str, str], dict | None],
-    genome_uuid_to_accession_id: Callable[[str], str | None],
+    genome_uuid_to_genome_tag: Callable[[str], str | None],
     view: str | None = None,
 ) -> str:
     """Resolve a legacy variant page using the variant search service."""
@@ -266,7 +266,7 @@ def _resolve_variant_url(
             "No supported new Ensembl equivalent for this variant"
         )
 
-    target_genome_id = genome_uuid_to_accession_id(genome_uuid) or genome_uuid
+    target_genome_id = genome_uuid_to_genome_tag(genome_uuid) or genome_uuid
     return _build_variant_feature_explorer_url(target_genome_id, variant, view)
 
 
@@ -509,7 +509,7 @@ def resolve_legacy_ensembl_url(
             genome_uuid,
             variant_id,
             variant_search,
-            genome_uuid_to_accession_id,
+            genome_uuid_to_genome_tag,
             variant_views[legacy_path],
         )
 

--- a/app/api/utils/legacy_url_resolver.py
+++ b/app/api/utils/legacy_url_resolver.py
@@ -231,6 +231,41 @@ def _build_transcript_protein_url(
     )
 
 
+def _build_variant_feature_explorer_url(genome_id: str, variant: dict) -> str:
+    """Build a Feature Explorer URL for a resolved variant search match."""
+    variant_name = variant.get("variant_name")
+    region_name = variant.get("region_name")
+    start = variant.get("start")
+
+    if not variant_name or not region_name or start is None:
+        raise UnsupportedLegacyUrlError(
+            "Variant search result does not contain a resolvable location"
+        )
+
+    return (
+        f"{ENSEMBL_URL}/feature-explorer/{_quote_url_part(genome_id)}"
+        f"/variant:{_quote_url_part(region_name)}:{_quote_url_part(start)}:"
+        f"{_quote_url_part(variant_name)}?allele=0"
+    )
+
+
+def _resolve_variant_explore_url(
+    genome_uuid: str,
+    variant_id: str,
+    variant_search: Callable[[str, str], dict | None],
+    genome_uuid_to_accession_id: Callable[[str], str | None],
+) -> str:
+    """Resolve a legacy variant page using the variant search service."""
+    variant = variant_search(genome_uuid, variant_id)
+    if variant is None:
+        raise UnsupportedLegacyUrlError(
+            "No supported new Ensembl equivalent for this variant"
+        )
+
+    target_genome_id = genome_uuid_to_accession_id(genome_uuid) or genome_uuid
+    return _build_variant_feature_explorer_url(target_genome_id, variant)
+
+
 # These rules intentionally cover only legacy URL shapes with a practical new
 # Ensembl equivalent. Unsupported shapes, or shapes needing extra
 # variant/regulatory lookup, should fail explicitly rather than produce a
@@ -402,6 +437,7 @@ def resolve_legacy_ensembl_url(
     legacy_url: str,
     species_to_genome_uuid: Callable[[str], str],
     genome_uuid_to_accession_id: Callable[[str], str | None],
+    variant_search: Callable[[str, str], dict | None],
     static_legacy_url_mapping: Callable[[str], str | None] | None = None,
 ) -> str:
     """Resolve a supported legacy Ensembl URL to its new Ensembl equivalent.
@@ -412,6 +448,7 @@ def resolve_legacy_ensembl_url(
             new Ensembl genome UUIDs.
         genome_uuid_to_accession_id: Function that maps current Ensembl genome
             UUIDs to assembly accession IDs when available.
+        variant_search: Function that finds a variant ID within a genome UUID.
         static_legacy_url_mapping: Optional function that maps configured legacy
             hosts or paths directly to their new Ensembl URLs.
 
@@ -455,6 +492,16 @@ def resolve_legacy_ensembl_url(
     # the supported mappings, e.g. /Homo_sapiens/Gene/Summary?g=...
     species_url = path_segments[0]
     legacy_path = path_segments[1:]
+
+    if legacy_path == ("Variation", "Explore"):
+        variant_id = _require_query_value(query_params, "v")
+        genome_uuid = species_to_genome_uuid(species_url)
+        return _resolve_variant_explore_url(
+            genome_uuid,
+            variant_id,
+            variant_search,
+            genome_uuid_to_accession_id,
+        )
 
     if legacy_path:
         # Species-scoped legacy pages resolve through the rule table. Unsupported

--- a/app/api/utils/legacy_url_resolver.py
+++ b/app/api/utils/legacy_url_resolver.py
@@ -500,6 +500,7 @@ def resolve_legacy_ensembl_url(
     variant_views = {
         ("Variation", "Explore"): None,
         ("Variation", "Mappings"): "transcript-consequences",
+        ("Variation", "Population"): "allele-frequencies",
     }
     if legacy_path in variant_views:
         variant_id = _require_query_value(query_params, "v")

--- a/app/api/utils/legacy_url_resolver.py
+++ b/app/api/utils/legacy_url_resolver.py
@@ -231,7 +231,9 @@ def _build_transcript_protein_url(
     )
 
 
-def _build_variant_feature_explorer_url(genome_id: str, variant: dict) -> str:
+def _build_variant_feature_explorer_url(
+    genome_id: str, variant: dict, view: str | None = None
+) -> str:
     """Build a Feature Explorer URL for a resolved variant search match."""
     variant_name = variant.get("variant_name")
     region_name = variant.get("region_name")
@@ -242,18 +244,20 @@ def _build_variant_feature_explorer_url(genome_id: str, variant: dict) -> str:
             "Variant search result does not contain a resolvable location"
         )
 
-    return (
+    url = (
         f"{ENSEMBL_URL}/feature-explorer/{_quote_url_part(genome_id)}"
         f"/variant:{_quote_url_part(region_name)}:{_quote_url_part(start)}:"
         f"{_quote_url_part(variant_name)}?allele=0"
     )
+    return f"{url}&view={_quote_url_part(view)}" if view else url
 
 
-def _resolve_variant_explore_url(
+def _resolve_variant_url(
     genome_uuid: str,
     variant_id: str,
     variant_search: Callable[[str, str], dict | None],
     genome_uuid_to_accession_id: Callable[[str], str | None],
+    view: str | None = None,
 ) -> str:
     """Resolve a legacy variant page using the variant search service."""
     variant = variant_search(genome_uuid, variant_id)
@@ -263,7 +267,7 @@ def _resolve_variant_explore_url(
         )
 
     target_genome_id = genome_uuid_to_accession_id(genome_uuid) or genome_uuid
-    return _build_variant_feature_explorer_url(target_genome_id, variant)
+    return _build_variant_feature_explorer_url(target_genome_id, variant, view)
 
 
 # These rules intentionally cover only legacy URL shapes with a practical new
@@ -493,14 +497,19 @@ def resolve_legacy_ensembl_url(
     species_url = path_segments[0]
     legacy_path = path_segments[1:]
 
-    if legacy_path == ("Variation", "Explore"):
+    variant_views = {
+        ("Variation", "Explore"): None,
+        ("Variation", "Mappings"): "transcript-consequences",
+    }
+    if legacy_path in variant_views:
         variant_id = _require_query_value(query_params, "v")
         genome_uuid = species_to_genome_uuid(species_url)
-        return _resolve_variant_explore_url(
+        return _resolve_variant_url(
             genome_uuid,
             variant_id,
             variant_search,
             genome_uuid_to_accession_id,
+            variant_views[legacy_path],
         )
 
     if legacy_path:

--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -71,3 +71,27 @@ def get_assembly_accession_id_from_genome_id(genome_id: str) -> str | None:
         raise Exception(
             f"Failed to fetch assembly accession for genome '{genome_id}': {error}"
         ) from error
+
+
+def search_variant(genome_id: str, variant_id: str) -> dict | None:
+    """Find a variant in a genome through the Ensembl variant search API."""
+    try:
+        session = requests.Session()
+        with session.post(
+            url=f"{ENSEMBL_URL}/api/search/variants",
+            json={"genome_ids": [genome_id], "query": variant_id},
+            timeout=10,
+        ) as response:
+            response.raise_for_status()
+            payload = response.json()
+
+        matches = payload.get("matches") if isinstance(payload, dict) else None
+        if not isinstance(matches, list) or not matches:
+            return None
+
+        first_match = matches[0]
+        return first_match if isinstance(first_match, dict) else None
+    except Exception as error:
+        raise Exception(
+            f"Failed to search for variant '{variant_id}' in genome '{genome_id}': {error}"
+        ) from error

--- a/tests/test_legacy_url_resolver.py
+++ b/tests/test_legacy_url_resolver.py
@@ -33,10 +33,16 @@ class TestUrlResolver(unittest.TestCase):
             self.assembly_accession_patcher.start()
         )
         self.mock_assembly_accession_lookup.return_value = self.assembly_accession_id
+        self.variant_search_patcher = patch(
+            "app.api.resources.legacy_url_resolver_view.search_variant"
+        )
+        self.mock_variant_search = self.variant_search_patcher.start()
+        self.mock_variant_search.return_value = None
 
     def tearDown(self):
         self.static_mapping_patcher.stop()
         self.assembly_accession_patcher.stop()
+        self.variant_search_patcher.stop()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_static_path_mapping_with_redirect(self, mock_species_lookup):
@@ -497,6 +503,80 @@ class TestUrlResolver(unittest.TestCase):
                 )
             },
         )
+
+    @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
+    def test_resolve_variation_explore(self, mock_species_lookup):
+        """Resolve a legacy variant URL through the variant search API."""
+        mock_species_lookup.return_value = self.genome_uuid
+        self.mock_variant_search.return_value = {
+            "variant_name": "rs99",
+            "genome_id": self.genome_uuid,
+            "region_name": "7",
+            "start": 24399036,
+        }
+
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={
+                "url": (
+                    "https://www.ensembl.org/Homo_sapiens/Variation/Explore"
+                    "?foo=bar;v=rs99;r=ignored"
+                )
+            },
+            headers={"accept": "application/json"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "resolved_url": (
+                    f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
+                    "/variant:7:24399036:rs99?allele=0"
+                )
+            },
+        )
+        mock_species_lookup.assert_called_once_with("Homo_sapiens")
+        self.mock_variant_search.assert_called_once_with(self.genome_uuid, "rs99")
+        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
+
+    @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
+    def test_resolve_variation_explore_requires_variant_id(self, mock_species_lookup):
+        """Return 400 when a variant URL does not provide the ``v`` parameter."""
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={
+                "url": "https://www.ensembl.org/Homo_sapiens/Variation/Explore?x=1"
+            },
+            headers={"accept": "application/json"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        mock_species_lookup.assert_not_called()
+        self.mock_variant_search.assert_not_called()
+        self.mock_assembly_accession_lookup.assert_not_called()
+
+    @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
+    def test_resolve_variation_explore_returns_404_when_not_found(
+        self, mock_species_lookup
+    ):
+        """Return 404 when the supplied variant cannot be found in the genome."""
+        mock_species_lookup.return_value = self.genome_uuid
+
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={
+                "url": "https://www.ensembl.org/Homo_sapiens/Variation/Explore?v=rs99"
+            },
+            headers={"accept": "application/json"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.mock_variant_search.assert_called_once_with(self.genome_uuid, "rs99")
+        self.mock_assembly_accession_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_missing_required_query_parameter(self, mock_species_lookup):

--- a/tests/test_legacy_url_resolver.py
+++ b/tests/test_legacy_url_resolver.py
@@ -575,6 +575,37 @@ class TestUrlResolver(unittest.TestCase):
         self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
+    def test_resolve_variation_population(self, mock_species_lookup):
+        """Resolve population pages with allele frequencies selected."""
+        mock_species_lookup.return_value = self.genome_uuid
+        self.mock_variant_search.return_value = {
+            "variant_name": "rs99",
+            "genome_id": self.genome_uuid,
+            "region_name": "7",
+            "start": 24399036,
+        }
+
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={
+                "url": "https://www.ensembl.org/Homo_sapiens/Variation/Population?v=rs99"
+            },
+            headers={"accept": "application/json"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "resolved_url": (
+                    f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
+                    "/variant:7:24399036:rs99?allele=0&view=allele-frequencies"
+                )
+            },
+        )
+
+    @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_variation_explore_requires_variant_id(self, mock_species_lookup):
         """Return 400 when a variant URL does not provide the ``v`` parameter."""
         response = self.client.get(

--- a/tests/test_legacy_url_resolver.py
+++ b/tests/test_legacy_url_resolver.py
@@ -542,6 +542,39 @@ class TestUrlResolver(unittest.TestCase):
         self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
+    def test_resolve_variation_mappings(self, mock_species_lookup):
+        """Resolve mappings pages with transcript consequences selected."""
+        mock_species_lookup.return_value = self.genome_uuid
+        self.mock_variant_search.return_value = {
+            "variant_name": "rs99",
+            "genome_id": self.genome_uuid,
+            "region_name": "7",
+            "start": 24399036,
+        }
+
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={
+                "url": "https://www.ensembl.org/Homo_sapiens/Variation/Mappings?v=rs99"
+            },
+            headers={"accept": "application/json"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "resolved_url": (
+                    f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
+                    "/variant:7:24399036:rs99?allele=0&view=transcript-consequences"
+                )
+            },
+        )
+        self.mock_variant_search.assert_called_once_with(self.genome_uuid, "rs99")
+        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
+
+    @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_variation_explore_requires_variant_id(self, mock_species_lookup):
         """Return 400 when a variant URL does not provide the ``v`` parameter."""
         response = self.client.get(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,7 +1,10 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from app.api.utils.metadata import get_assembly_accession_id_from_genome_id
+from app.api.utils.metadata import (
+    get_assembly_accession_id_from_genome_id,
+    search_variant,
+)
 from app.core.config import ENSEMBL_URL
 
 
@@ -46,6 +49,41 @@ class TestMetadata(unittest.TestCase):
             "Failed to fetch assembly accession for genome 'genome_uuid1': 503 Server Error",
         ):
             get_assembly_accession_id_from_genome_id("genome_uuid1")
+
+    @patch("app.api.utils.metadata.requests.Session")
+    def test_search_variant_posts_genome_and_variant_id(self, mock_session_class):
+        genome_id = "genome_uuid1"
+        response = MagicMock()
+        response.json.return_value = {
+            "matches": [
+                {
+                    "variant_name": "rs99",
+                    "genome_id": genome_id,
+                    "region_name": "7",
+                    "start": 24399036,
+                }
+            ]
+        }
+        session = mock_session_class.return_value
+        session.post.return_value.__enter__.return_value = response
+
+        result = search_variant(genome_id, "rs99")
+
+        self.assertEqual(result, response.json.return_value["matches"][0])
+        session.post.assert_called_once_with(
+            url=f"{ENSEMBL_URL}/api/search/variants",
+            json={"genome_ids": [genome_id], "query": "rs99"},
+            timeout=10,
+        )
+        response.raise_for_status.assert_called_once_with()
+
+    @patch("app.api.utils.metadata.requests.Session")
+    def test_search_variant_returns_none_when_no_matches(self, mock_session_class):
+        response = MagicMock()
+        response.json.return_value = {"matches": []}
+        mock_session_class.return_value.post.return_value.__enter__.return_value = response
+
+        self.assertIsNone(search_variant("genome_uuid1", "rs99"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds dynamic legacy URL resolution for variant URLs:
* /Variation/Explore?v=<variant> → Feature Explorer variant page
* /Variation/Mappings?v=<variant> → variant page with transcript consequences selected
* /Variation/Population?v=<variant> → variant page with allele frequencies selected

The resolver maps species to a genome UUID, searches the variant API for the variant location, obtains the genome GCA accession through metadata, and constructs the Feature Explorer URL.