### PR TITLE
Use correct metadata field

### DIFF
--- a/app/api/resources/legacy_url_resolver_view.py
+++ b/app/api/resources/legacy_url_resolver_view.py
@@ -6,7 +6,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from app.api.error_response import response_error_handler
 from app.api.models.resolver import UrlResolverResponse
 from app.api.utils.commons import is_json_request
-from app.api.utils.metadata import get_assembly_accession_id_from_genome_id
+from app.api.utils.metadata import get_genome_tag_from_genome_id
 from app.api.utils.species_mapping import (
     SpeciesMappingNotFoundError,
     SpeciesMappingConfigurationError,
@@ -48,7 +48,7 @@ async def resolve_url(request: Request, url: str):
         resolved_url = resolve_legacy_ensembl_url(
             url,
             get_genome_uuid_from_species_url,
-            get_assembly_accession_id_from_genome_id,
+            get_genome_tag_from_genome_id,
             get_static_legacy_url_mapping,
         )
         response = UrlResolverResponse(resolved_url=resolved_url)

--- a/app/api/utils/legacy_url_resolver.py
+++ b/app/api/utils/legacy_url_resolver.py
@@ -401,7 +401,7 @@ def _find_species_rule(
 def resolve_legacy_ensembl_url(
     legacy_url: str,
     species_to_genome_uuid: Callable[[str], str],
-    genome_uuid_to_accession_id: Callable[[str], str | None],
+    genome_uuid_to_genome_tag: Callable[[str], str | None],
     static_legacy_url_mapping: Callable[[str], str | None] | None = None,
 ) -> str:
     """Resolve a supported legacy Ensembl URL to its new Ensembl equivalent.
@@ -410,8 +410,8 @@ def resolve_legacy_ensembl_url(
         legacy_url: Full legacy URL or path submitted by the caller.
         species_to_genome_uuid: Function that maps legacy species URL names to
             new Ensembl genome UUIDs.
-        genome_uuid_to_accession_id: Function that maps current Ensembl genome
-            UUIDs to assembly accession IDs when available.
+        genome_uuid_to_genome_tag: Function that maps current Ensembl genome
+            UUIDs to genome tags when available.
         static_legacy_url_mapping: Optional function that maps configured legacy
             hosts or paths directly to their new Ensembl URLs.
 
@@ -469,5 +469,5 @@ def resolve_legacy_ensembl_url(
         build_url = _build_species_url
 
     genome_uuid = species_to_genome_uuid(species_url)
-    target_genome_id = genome_uuid_to_accession_id(genome_uuid) or genome_uuid
+    target_genome_id = genome_uuid_to_genome_tag(genome_uuid) or genome_uuid
     return build_url(target_genome_id, query_params)

--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -45,14 +45,14 @@ def get_genome_id_from_assembly_accession_id(accession_id: str):
         ) from e
 
 
-def get_assembly_accession_id_from_genome_id(genome_id: str) -> str | None:
-    """Fetch the assembly accession ID for a current Ensembl genome ID.
+def get_genome_tag_from_genome_id(genome_id: str) -> str | None:
+    """Fetch the genome tag for a current Ensembl genome ID.
 
     Args:
         genome_id: Current Ensembl genome UUID.
 
     Returns:
-        The assembly accession ID, or ``None`` when the genome has no accession.
+        The genome tag, or ``None`` when the genome has no tag.
 
     Raises:
         Exception: If the metadata explain endpoint cannot be queried or decoded.
@@ -64,10 +64,9 @@ def get_assembly_accession_id_from_genome_id(genome_id: str) -> str | None:
             response.raise_for_status()
             payload = response.json()
 
-        assembly = payload.get("assembly") if isinstance(payload, dict) else None
-        accession_id = assembly.get("accession_id") if isinstance(assembly, dict) else None
-        return accession_id or None
+        genome_tag = payload.get("genome_tag") if isinstance(payload, dict) else None
+        return genome_tag or None
     except Exception as error:
         raise Exception(
-            f"Failed to fetch assembly accession for genome '{genome_id}': {error}"
+            f"Failed to fetch genome tag for genome '{genome_id}': {error}"
         ) from error

--- a/tests/test_legacy_url_resolver.py
+++ b/tests/test_legacy_url_resolver.py
@@ -19,24 +19,23 @@ class TestUrlResolver(unittest.TestCase):
         api_prefix = "" if APP_PREFIX == "/" else APP_PREFIX
         self.mock_url_resolver_api_url = f"{api_prefix}/legacy"
         self.genome_uuid = "genome_uuid1"
-        self.assembly_accession_id = "GCA_01234567.1"
+        self.genome_tag = "GCA_01234567.1"
         self.static_mapping_patcher = patch(
             "app.api.resources.legacy_url_resolver_view.get_static_legacy_url_mapping"
         )
         self.mock_static_mapping = self.static_mapping_patcher.start()
         self.mock_static_mapping.return_value = None
-        self.assembly_accession_patcher = patch(
-            "app.api.resources.legacy_url_resolver_view."
-            "get_assembly_accession_id_from_genome_id"
+        self.genome_tag_patcher = patch(
+            "app.api.resources.legacy_url_resolver_view.get_genome_tag_from_genome_id"
         )
-        self.mock_assembly_accession_lookup = (
-            self.assembly_accession_patcher.start()
+        self.mock_genome_tag_lookup = (
+            self.genome_tag_patcher.start()
         )
-        self.mock_assembly_accession_lookup.return_value = self.assembly_accession_id
+        self.mock_genome_tag_lookup.return_value = self.genome_tag
 
     def tearDown(self):
         self.static_mapping_patcher.stop()
-        self.assembly_accession_patcher.stop()
+        self.genome_tag_patcher.stop()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_static_path_mapping_with_redirect(self, mock_species_lookup):
@@ -65,7 +64,7 @@ class TestUrlResolver(unittest.TestCase):
             "https://staging-plants.ensembl.org/Multi/Tools/Blast/?discard=this"
         )
         mock_species_lookup.assert_not_called()
-        self.mock_assembly_accession_lookup.assert_not_called()
+        self.mock_genome_tag_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_static_host_mapping_with_json_response(self, mock_species_lookup):
@@ -86,7 +85,7 @@ class TestUrlResolver(unittest.TestCase):
         )
         self.mock_static_mapping.assert_called_once_with("staging-protists.ensembl.org")
         mock_species_lookup.assert_not_called()
-        self.mock_assembly_accession_lookup.assert_not_called()
+        self.mock_genome_tag_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_info_paths_to_archive_hosts(self, mock_species_lookup):
@@ -134,7 +133,7 @@ class TestUrlResolver(unittest.TestCase):
                 self.assertEqual(response.json(), {"resolved_url": expected_url})
                 self.mock_static_mapping.assert_not_called()
                 mock_species_lookup.assert_not_called()
-                self.mock_assembly_accession_lookup.assert_not_called()
+                self.mock_genome_tag_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_info_archive_preserves_query_and_fragment(
@@ -162,7 +161,7 @@ class TestUrlResolver(unittest.TestCase):
         )
         self.mock_static_mapping.assert_not_called()
         mock_species_lookup.assert_not_called()
-        self.mock_assembly_accession_lookup.assert_not_called()
+        self.mock_genome_tag_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_info_unknown_host_does_not_redirect(self, mock_species_lookup):
@@ -178,7 +177,7 @@ class TestUrlResolver(unittest.TestCase):
         self.assertNotIn("location", response.headers)
         self.mock_static_mapping.assert_not_called()
         mock_species_lookup.assert_not_called()
-        self.mock_assembly_accession_lookup.assert_not_called()
+        self.mock_genome_tag_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_species_home_with_json_response(self, mock_species_lookup):
@@ -195,10 +194,10 @@ class TestUrlResolver(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            {"resolved_url": f"{ENSEMBL_URL}/genome/{self.assembly_accession_id}"},
+            {"resolved_url": f"{ENSEMBL_URL}/genome/{self.genome_tag}"},
         )
         mock_species_lookup.assert_called_once_with("Homo_sapiens")
-        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
+        self.mock_genome_tag_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_bare_species_path_with_redirect(self, mock_species_lookup):
@@ -214,10 +213,10 @@ class TestUrlResolver(unittest.TestCase):
         self.assertEqual(response.status_code, 308)
         self.assertEqual(
             response.headers["location"],
-            f"{ENSEMBL_URL}/genome/{self.assembly_accession_id}",
+            f"{ENSEMBL_URL}/genome/{self.genome_tag}",
         )
         mock_species_lookup.assert_called_once_with("Crocodylus_porosus")
-        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
+        self.mock_genome_tag_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_bare_species_path_without_uuid_redirects_to_archive(
@@ -259,17 +258,17 @@ class TestUrlResolver(unittest.TestCase):
         self.assertEqual(
             response.headers["location"],
             (
-                f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
+                f"{ENSEMBL_URL}/feature-explorer/{self.genome_tag}"
                 "/gene:ENSG00000012048"
             ),
         )
-        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
+        self.mock_genome_tag_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
-    def test_resolve_gene_summary_uses_accession_for_uuid_lookup_value(
+    def test_resolve_gene_summary_uses_genome_tag_for_uuid_lookup_value(
         self, mock_species_lookup
     ):
-        """Pass mapped UUIDs to metadata and use the returned accession."""
+        """Pass mapped UUIDs to metadata and use the returned genome tag."""
         genome_uuid = UUID("12345678-1234-5678-1234-567812345678")
         mock_species_lookup.return_value = genome_uuid
 
@@ -290,20 +289,20 @@ class TestUrlResolver(unittest.TestCase):
             response.json(),
             {
                 "resolved_url": (
-                    f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
+                    f"{ENSEMBL_URL}/feature-explorer/{self.genome_tag}"
                     "/gene:ENSG00000012048"
                 )
             },
         )
-        self.mock_assembly_accession_lookup.assert_called_once_with(genome_uuid)
+        self.mock_genome_tag_lookup.assert_called_once_with(genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
-    def test_resolve_gene_summary_without_accession_uses_genome_uuid(
+    def test_resolve_gene_summary_without_genome_tag_uses_genome_uuid(
         self, mock_species_lookup
     ):
-        """Retain the current genome UUID when metadata has no accession."""
+        """Retain the current genome UUID when metadata has no genome tag."""
         mock_species_lookup.return_value = self.genome_uuid
-        self.mock_assembly_accession_lookup.return_value = None
+        self.mock_genome_tag_lookup.return_value = None
 
         response = self.client.get(
             self.mock_url_resolver_api_url,
@@ -327,16 +326,16 @@ class TestUrlResolver(unittest.TestCase):
                 )
             },
         )
-        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
+        self.mock_genome_tag_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
-    def test_resolve_gene_summary_returns_500_for_accession_lookup_failure(
+    def test_resolve_gene_summary_returns_500_for_genome_tag_lookup_failure(
         self, mock_species_lookup
     ):
         """Return an error when the explain endpoint cannot be queried."""
         mock_species_lookup.return_value = self.genome_uuid
-        self.mock_assembly_accession_lookup.side_effect = Exception(
-            "Failed to fetch assembly accession for genome 'genome_uuid1': 503 Server Error"
+        self.mock_genome_tag_lookup.side_effect = Exception(
+            "Failed to fetch genome tag for genome 'genome_uuid1': 503 Server Error"
         )
 
         response = self.client.get(
@@ -352,8 +351,8 @@ class TestUrlResolver(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 500)
-        self.assertIn("Failed to fetch assembly accession", response.text)
-        self.mock_assembly_accession_lookup.assert_called_once_with(self.genome_uuid)
+        self.assertIn("Failed to fetch genome tag", response.text)
+        self.mock_genome_tag_lookup.assert_called_once_with(self.genome_uuid)
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_location_view_with_semicolon_query(self, mock_species_lookup):
@@ -377,7 +376,7 @@ class TestUrlResolver(unittest.TestCase):
             response.json(),
             {
                 "resolved_url": (
-                    f"{ENSEMBL_URL}/genome-browser/{self.assembly_accession_id}"
+                    f"{ENSEMBL_URL}/genome-browser/{self.genome_tag}"
                     "?focus=location:17:38449840-38530994"
                     "&location=17:38449840-38530994"
                 )
@@ -406,7 +405,7 @@ class TestUrlResolver(unittest.TestCase):
             response.json(),
             {
                 "resolved_url": (
-                    f"{ENSEMBL_URL}/genome-browser/{self.assembly_accession_id}"
+                    f"{ENSEMBL_URL}/genome-browser/{self.genome_tag}"
                     "?focus=transcript:ENST00000357654"
                 )
             },
@@ -436,7 +435,7 @@ class TestUrlResolver(unittest.TestCase):
                     response.json(),
                     {
                         "resolved_url": (
-                            f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
+                            f"{ENSEMBL_URL}/feature-explorer/{self.genome_tag}"
                             "/gene:ENSG00000012048"
                         )
                     },
@@ -464,7 +463,7 @@ class TestUrlResolver(unittest.TestCase):
             response.json(),
             {
                 "resolved_url": (
-                    f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
+                    f"{ENSEMBL_URL}/feature-explorer/{self.genome_tag}"
                     "/transcript:ENST00000357654"
                 )
             },
@@ -492,7 +491,7 @@ class TestUrlResolver(unittest.TestCase):
             response.json(),
             {
                 "resolved_url": (
-                    f"{ENSEMBL_URL}/feature-explorer/{self.assembly_accession_id}"
+                    f"{ENSEMBL_URL}/feature-explorer/{self.genome_tag}"
                     "/transcript:ENST00000357654"
                 )
             },
@@ -531,7 +530,7 @@ class TestUrlResolver(unittest.TestCase):
 
         self.assertEqual(response.status_code, 404)
         mock_species_lookup.assert_not_called()
-        self.mock_assembly_accession_lookup.assert_not_called()
+        self.mock_genome_tag_lookup.assert_not_called()
 
     @patch("app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url")
     def test_resolve_missing_species_redirects_to_main_archive(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,22 +1,22 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from app.api.utils.metadata import get_assembly_accession_id_from_genome_id
+from app.api.utils.metadata import get_genome_tag_from_genome_id
 from app.core.config import ENSEMBL_URL
 
 
 class TestMetadata(unittest.TestCase):
     @patch("app.api.utils.metadata.requests.Session")
-    def test_get_assembly_accession_id_from_genome_id(self, mock_session_class):
+    def test_get_genome_tag_from_genome_id(self, mock_session_class):
         genome_id = "genome_uuid1"
         response = MagicMock()
-        response.json.return_value = {"assembly": {"accession_id": "GCA_01234567.1"}}
+        response.json.return_value = {"genome_tag": "GCA_01234567.1"}
         session = mock_session_class.return_value
         session.get.return_value.__enter__.return_value = response
 
-        accession_id = get_assembly_accession_id_from_genome_id(genome_id)
+        genome_tag = get_genome_tag_from_genome_id(genome_id)
 
-        self.assertEqual(accession_id, "GCA_01234567.1")
+        self.assertEqual(genome_tag, "GCA_01234567.1")
         session.get.assert_called_once_with(
             url=f"{ENSEMBL_URL}/api/metadata/genome/{genome_id}/explain",
             timeout=10,
@@ -24,28 +24,28 @@ class TestMetadata(unittest.TestCase):
         response.raise_for_status.assert_called_once_with()
 
     @patch("app.api.utils.metadata.requests.Session")
-    def test_get_assembly_accession_id_returns_none_when_accession_is_absent(
+    def test_get_genome_tag_returns_none_when_tag_is_absent(
         self, mock_session_class
     ):
         response = MagicMock()
-        response.json.return_value = {"assembly": {}}
+        response.json.return_value = {}
         mock_session_class.return_value.get.return_value.__enter__.return_value = response
 
-        accession_id = get_assembly_accession_id_from_genome_id("genome_uuid1")
+        genome_tag = get_genome_tag_from_genome_id("genome_uuid1")
 
-        self.assertIsNone(accession_id)
+        self.assertIsNone(genome_tag)
 
     @patch("app.api.utils.metadata.requests.Session")
-    def test_get_assembly_accession_id_wraps_endpoint_errors(self, mock_session_class):
+    def test_get_genome_tag_wraps_endpoint_errors(self, mock_session_class):
         response = MagicMock()
         response.raise_for_status.side_effect = Exception("503 Server Error")
         mock_session_class.return_value.get.return_value.__enter__.return_value = response
 
         with self.assertRaisesRegex(
             Exception,
-            "Failed to fetch assembly accession for genome 'genome_uuid1': 503 Server Error",
+            "Failed to fetch genome tag for genome 'genome_uuid1': 503 Server Error",
         ):
-            get_assembly_accession_id_from_genome_id("genome_uuid1")
+            get_genome_tag_from_genome_id("genome_uuid1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use `genome_tag` instead of `accession_id` field in metadata API payload when resolving legacy species URLs.