### PR TITLE
:bug: Fix legacy resolver handling of missing metadata genomes

### DIFF
--- a/app/api/resources/legacy_url_resolver_view.py
+++ b/app/api/resources/legacy_url_resolver_view.py
@@ -7,6 +7,7 @@ from app.api.error_response import response_error_handler
 from app.api.models.resolver import UrlResolverResponse
 from app.api.utils.commons import is_json_request
 from app.api.utils.metadata import (
+    MetadataNotFoundError,
     get_genome_tag_from_genome_id,
     search_variant,
 )
@@ -85,6 +86,8 @@ async def resolve_url(request: Request, url: str):
         if not is_json_request(request):
             return _url_resolver_interstitial_response(url)
 
+        return response_error_handler({"status": 404, "details": str(error)})
+    except MetadataNotFoundError as error:
         return response_error_handler({"status": 404, "details": str(error)})
     except SpeciesMappingConfigurationError as error:
         logging.error(f"Species mapping configuration error: {error}")

--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -5,6 +5,10 @@ from app.api.models.resolver import SearchMatch
 from app.core.config import ENSEMBL_URL
 
 
+class MetadataNotFoundError(Exception):
+    """Raised when a requested genome is absent from the metadata API."""
+
+
 def get_metadata(matches: List[SearchMatch] = []):
 
     metadata_results = {}
@@ -65,6 +69,14 @@ def get_genome_tag_from_genome_id(genome_id: str) -> str | None:
 
         genome_tag = payload.get("genome_tag") if isinstance(payload, dict) else None
         return genome_tag or None
+    except requests.HTTPError as error:
+        if error.response is not None and error.response.status_code == 404:
+            raise MetadataNotFoundError(
+                f"Genome '{genome_id}' was not found in the metadata API"
+            ) from error
+        raise Exception(
+            f"Failed to fetch genome tag for genome '{genome_id}': {error}"
+        ) from error
     except Exception as error:
         raise Exception(
             f"Failed to fetch genome tag for genome '{genome_id}': {error}"

--- a/tests/test_legacy_url_resolver.py
+++ b/tests/test_legacy_url_resolver.py
@@ -538,6 +538,36 @@ class TestUrlResolver(unittest.TestCase):
     @patch(
         "app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url"
     )
+    def test_resolve_gene_summary_returns_404_when_genome_metadata_is_missing(
+        self, mock_species_lookup
+    ):
+        """Do not convert a missing metadata genome into a server error."""
+        from app.api.utils.metadata import MetadataNotFoundError
+
+        mock_species_lookup.return_value = self.genome_uuid
+        self.mock_genome_tag_lookup.side_effect = MetadataNotFoundError(
+            f"Genome '{self.genome_uuid}' was not found in the metadata API"
+        )
+
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={
+                "url": (
+                    "https://www.ensembl.org/Homo_sapiens/Gene/Summary"
+                    "?g=ENSG00000012048"
+                )
+            },
+            headers={"accept": "application/json"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("was not found in the metadata API", response.text)
+        self.mock_genome_tag_lookup.assert_called_once_with(self.genome_uuid)
+
+    @patch(
+        "app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url"
+    )
     def test_resolve_location_genome_with_region(self, mock_species_lookup):
         """Resolve Location/Genome URLs with a region to genome browser focus."""
         mock_species_lookup.return_value = self.genome_uuid

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,7 +1,10 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from app.api.utils.metadata import (
+    MetadataNotFoundError,
     get_genome_tag_from_genome_id,
     search_variant,
 )
@@ -49,6 +52,22 @@ class TestMetadata(unittest.TestCase):
         with self.assertRaisesRegex(
             Exception,
             "Failed to fetch genome tag for genome 'genome_uuid1': 503 Server Error",
+        ):
+            get_genome_tag_from_genome_id("genome_uuid1")
+
+    @patch("app.api.utils.metadata.requests.Session")
+    def test_get_genome_tag_raises_not_found_for_a_missing_genome(
+        self, mock_session_class
+    ):
+        response = MagicMock(status_code=404)
+        response.raise_for_status.side_effect = requests.HTTPError(response=response)
+        mock_session_class.return_value.get.return_value.__enter__.return_value = (
+            response
+        )
+
+        with self.assertRaisesRegex(
+            MetadataNotFoundError,
+            "Genome 'genome_uuid1' was not found in the metadata API",
         ):
             get_genome_tag_from_genome_id("genome_uuid1")
 


### PR DESCRIPTION
Metadata API 404 responses are now preserved as `MetadataNotFoundError` and mapped to an `HTTP 404` by the legacy URL resolver, instead of being wrapped as generic exceptions and returned as `500s`. Other metadata failures continue to return `500`