### PR TITLE
Enhance legacy URL resolver metrics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ python3 -m uvicorn app.main:app --port 8001 --reload
 
 `APP_PREFIX` defaults to `/`. Set it only when the app should be served under a path prefix, for example `/api/resolver`.
 
+### Legacy URL resolver metrics
+
+In addition to HTTP metrics, `/metrics` exposes
+`legacy_url_resolver_requests_total`. Its `outcome` label records the resolver
+result independently of the HTTP status:
+
+| Outcome | Meaning |
+| --- | --- |
+| `resolved` | A new Ensembl URL was returned or redirected to. |
+| `archive_fallback` | The request was redirected to an Ensembl archive. |
+| `interstitial` | A browser was shown the expected HTML interstitial (HTTP 404). |
+| `not_found` | No suitable destination was found. |
+| `invalid_request` | The submitted URL was invalid. |
+| `internal_error` | An unexpected resolver or configuration failure occurred. |
+
+We can use `outcome="internal_error"` for the resolver failure alert and track
+`outcome="interstitial"` separately, rather than treating its expected HTTP
+404 response as a service failure.
+
 ### Stable ID index
 
 `/id/{stable_id}` and `/rapid/id/{stable_id}` can use a local fast-match Redb

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -1,0 +1,22 @@
+"""Application-specific Prometheus metrics."""
+
+from prometheus_client import Counter
+
+
+LEGACY_URL_RESOLVER_REQUESTS = Counter(
+    "legacy_url_resolver_requests",
+    "Legacy URL resolver requests by outcome and response mode.",
+    ("outcome", "response_mode"),
+)
+
+
+def record_legacy_url_resolver_outcome(outcome: str, response_mode: str) -> None:
+    """Record the product outcome of one legacy resolver request.
+
+    HTTP status codes retain their protocol meaning, while this metric separates
+    expected user-facing outcomes (such as an HTML interstitial) from failures
+    that need operational attention.
+    """
+    LEGACY_URL_RESOLVER_REQUESTS.labels(
+        outcome=outcome, response_mode=response_mode
+    ).inc()

--- a/app/api/resources/legacy_url_resolver_view.py
+++ b/app/api/resources/legacy_url_resolver_view.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from app.api.error_response import response_error_handler
+from app.api.metrics import record_legacy_url_resolver_outcome
 from app.api.models.resolver import UrlResolverResponse
 from app.api.utils.commons import is_json_request
 from app.api.utils.metadata import (
@@ -48,6 +49,8 @@ async def resolve_url(request: Request, url: str):
         JSON containing ``resolved_url`` when the client requests JSON, otherwise
         a redirect response to the resolved new Ensembl URL.
     """
+    response_mode = "json" if is_json_request(request) else "html"
+
     try:
         resolved_url = resolve_legacy_ensembl_url(
             url,
@@ -58,48 +61,58 @@ async def resolve_url(request: Request, url: str):
         )
         response = UrlResolverResponse(resolved_url=resolved_url)
 
-        if is_json_request(request):
+        if response_mode == "json":
+            record_legacy_url_resolver_outcome("resolved", response_mode)
             return response.model_dump(exclude_none=True)
 
+        record_legacy_url_resolver_outcome("resolved", response_mode)
         return RedirectResponse(resolved_url, status_code=308)
     except MissingUrlParameterError as error:
+        record_legacy_url_resolver_outcome("invalid_request", response_mode)
         return response_error_handler({"status": 400, "details": str(error)})
     except SpeciesMappingNotFoundError:
         if is_bare_legacy_path(url):
-            if not is_json_request(request):
-                return _url_resolver_interstitial_response(url)
+            if response_mode == "html":
+                return _url_resolver_interstitial_response(url, response_mode)
+            record_legacy_url_resolver_outcome("not_found", response_mode)
             return response_error_handler(
                 {
                     "status": 404,
                     "details": "No supported new Ensembl equivalent for this URL",
                 }
             )
-        return _archive_fallback_response(url)
+        return _archive_fallback_response(url, response_mode)
     except SpeciesNotFoundError:
         # Archive fallback is an HTTP policy for unresolved species mappings.
         # The new Ensembl URL resolver stays focused on supported new Ensembl
         # destinations.
-        return _archive_fallback_response(url)
+        return _archive_fallback_response(url, response_mode)
     except InvalidLegacyUrlError as error:
+        record_legacy_url_resolver_outcome("not_found", response_mode)
         return response_error_handler({"status": 404, "details": str(error)})
     except UnsupportedLegacyUrlError as error:
-        if not is_json_request(request):
-            return _url_resolver_interstitial_response(url)
+        if response_mode == "html":
+            return _url_resolver_interstitial_response(url, response_mode)
 
+        record_legacy_url_resolver_outcome("not_found", response_mode)
         return response_error_handler({"status": 404, "details": str(error)})
     except MetadataNotFoundError as error:
+        record_legacy_url_resolver_outcome("not_found", response_mode)
         return response_error_handler({"status": 404, "details": str(error)})
     except SpeciesMappingConfigurationError as error:
         logging.error(f"Species mapping configuration error: {error}")
+        record_legacy_url_resolver_outcome("internal_error", response_mode)
         return response_error_handler({"status": 500, "details": str(error)})
     except LegacyUrlResolverError as error:
+        record_legacy_url_resolver_outcome("invalid_request", response_mode)
         return response_error_handler({"status": 400, "details": str(error)})
     except Exception as error:
         logging.error(f"Error resolving legacy URL: {error}")
+        record_legacy_url_resolver_outcome("internal_error", response_mode)
         return response_error_handler({"status": 500, "details": str(error)})
 
 
-def _archive_fallback_response(url: str):
+def _archive_fallback_response(url: str, response_mode: str):
     """Redirect to the archive equivalent for unresolved species mappings.
 
     Args:
@@ -111,14 +124,17 @@ def _archive_fallback_response(url: str):
     """
     try:
         archive_url = build_archive_fallback_url(url)
+        record_legacy_url_resolver_outcome("archive_fallback", response_mode)
         return RedirectResponse(archive_url, status_code=308)
     except UnsupportedLegacyUrlError as error:
+        record_legacy_url_resolver_outcome("not_found", response_mode)
         return response_error_handler({"status": 404, "details": str(error)})
     except InvalidLegacyUrlError as error:
+        record_legacy_url_resolver_outcome("not_found", response_mode)
         return response_error_handler({"status": 404, "details": str(error)})
 
 
-def _url_resolver_interstitial_response(url: str):
+def _url_resolver_interstitial_response(url: str, response_mode: str):
     """Render an interstitial with new Ensembl and archive choices.
 
     Args:
@@ -133,6 +149,7 @@ def _url_resolver_interstitial_response(url: str):
     except (InvalidLegacyUrlError, UnsupportedLegacyUrlError):
         archive_url = None
 
+    record_legacy_url_resolver_outcome("interstitial", response_mode)
     response = UrlResolverResponse(
         source_url=url,
         archive_url=archive_url,

--- a/tests/test_legacy_url_resolver.py
+++ b/tests/test_legacy_url_resolver.py
@@ -72,6 +72,66 @@ class TestUrlResolver(unittest.TestCase):
         self.mock_genome_tag_lookup.assert_not_called()
 
     @patch(
+        "app.api.resources.legacy_url_resolver_view.record_legacy_url_resolver_outcome"
+    )
+    def test_records_resolved_outcome(self, mock_record_outcome):
+        """Record successful browser redirects as resolved."""
+        self.mock_static_mapping.return_value = "https://www.ensembl.org/tools/blast"
+
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={"url": "https://staging.ensembl.org/Multi/Tools/Blast/"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 308)
+        mock_record_outcome.assert_called_once_with("resolved", "html")
+
+    @patch(
+        "app.api.resources.legacy_url_resolver_view.record_legacy_url_resolver_outcome"
+    )
+    @patch(
+        "app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url"
+    )
+    def test_records_archive_fallback_outcome(
+        self, mock_species_lookup, mock_record_outcome
+    ):
+        """Record redirects to an archive as archive fallbacks."""
+        mock_species_lookup.side_effect = SpeciesNotFoundError("not found")
+
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={
+                "url": "https://www.ensembl.org/Homo_sapiens/Gene/Summary?g=ENSG1"
+            },
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 308)
+        mock_record_outcome.assert_called_once_with("archive_fallback", "html")
+
+    @patch(
+        "app.api.resources.legacy_url_resolver_view.record_legacy_url_resolver_outcome"
+    )
+    @patch(
+        "app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url"
+    )
+    def test_records_interstitial_outcome(
+        self, mock_species_lookup, mock_record_outcome
+    ):
+        """Record browser interstitials separately from ordinary not-found results."""
+        mock_species_lookup.side_effect = SpeciesMappingNotFoundError("not found")
+
+        response = self.client.get(
+            self.mock_url_resolver_api_url,
+            params={"url": "https://www.ensembl.org/foo"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 404)
+        mock_record_outcome.assert_called_once_with("interstitial", "html")
+
+    @patch(
         "app.api.resources.legacy_url_resolver_view.get_genome_uuid_from_species_url"
     )
     def test_resolve_static_host_mapping_with_json_response(self, mock_species_lookup):


### PR DESCRIPTION
## Add resolver outcome metrics for accurate monitoring

### Summary

Adds a product-level Prometheus metric for legacy URL resolver outcomes, so expected browser interstitials are no longer interpreted as resolver failures solely because they return HTTP `404`.

The existing HTTP status metrics remain unchanged. The resolver now additionally exposes:

```
legacy_url_resolver_requests_total{outcome, response_mode}
```

### Outcomes recorded

Outcome | Meaning
-- | --
resolved | A new Ensembl URL was returned or redirected to
archive_fallback | Request redirected to the corresponding Ensembl archive URL
interstitial | Browser received the expected HTML interstitial page (404)
not_found | Valid request with no suitable resolver destination
invalid_request | Malformed or unsupported request input
internal_error | Unexpected resolver/configuration failure

`response_mode` distinguishes HTML/browser and JSON/API responses.

The legacy resolver deliberately serves an HTML interstitial with HTTP `404` when a browser reaches an unsupported legacy URL. This is an expected user-facing outcome, but it inflated the HTTP 4xx error rate in Grafana and obscured genuine resolver failures.

Separating resolver outcomes from HTTP transport status gives us clearer operational signals:
```
HTTP status metrics      → protocol and traffic diagnostics
Resolver outcome metric  → product behaviour and service reliability
```

### Dashboard / alerting guidance

* Alert on `outcome="internal_error"`.
* Track `outcome="interstitial"` as a separate count and percentage of resolver traffic.
* Keep raw HTTP 4xx/5xx panels for diagnostic visibility, but do not use total 4xx volume as the resolver failure signal.
 
Example queries:
```
sum(rate(legacy_url_resolver_requests_total{outcome="internal_error"}[5m]))

sum(rate(legacy_url_resolver_requests_total{outcome="interstitial"}[5m]))
```