### PR TITLE
✨ Enhance metadata filtering to prioritize reference assemblies

### DIFF
--- a/app/api/utils/metadata.py
+++ b/app/api/utils/metadata.py
@@ -97,11 +97,21 @@ def _filter_metadata_releases(metadata_results):
             latest = max(non_archive, key=lambda release: _release_sort_key(release[1]))
             selected_genomes.add(latest[0])
 
-    return {
+    filtered = {
         genome_id: metadata
         for genome_id, metadata in metadata_results.items()
         if genome_id in selected_genomes
     }
+
+    # Prefer reference assemblies when at least one reference result remains.
+    # If every remaining result is non-reference, keep the release-filtered
+    # results rather than returning an empty list.
+    reference_results = {
+        genome_id: metadata
+        for genome_id, metadata in filtered.items()
+        if metadata.get("is_reference") is True
+    }
+    return reference_results or filtered
 
 
 def _release_sort_key(metadata):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -83,6 +83,35 @@ class TestMetadata(unittest.TestCase):
         )
 
     @patch("app.api.utils.metadata.requests.Session")
+    def test_get_metadata_prefers_reference_results(self, mock_session_class):
+        responses = {
+            "genome-38": {
+                "assembly": {"accession_id": "GCA-38", "name": "GRCh38"},
+                "is_reference": True,
+                "release": {"type": "integrated", "name": "2026-07"},
+            },
+            "genome-37": {
+                "assembly": {"accession_id": "GCA-37", "name": "GRCh37"},
+                "is_reference": False,
+                "release": {"type": "integrated", "name": "2026-07"},
+            },
+        }
+
+        def response_for_genome(url, timeout):
+            response = MagicMock()
+            genome_id = url.split("/genome/")[1].split("/")[0]
+            response.json.return_value = responses[genome_id]
+            context = MagicMock()
+            context.__enter__.return_value = response
+            return context
+
+        mock_session_class.return_value.get.side_effect = response_for_genome
+
+        result = get_metadata([{"genome_id": genome_id} for genome_id in responses])
+
+        self.assertEqual(list(result), ["genome-38"])
+
+    @patch("app.api.utils.metadata.requests.Session")
     def test_get_genome_tag_from_genome_id(self, mock_session_class):
         genome_id = "genome_uuid1"
         response = MagicMock()


### PR DESCRIPTION
After release filtering (PR #47):
- If any result has `is_reference: true`, only reference results are returned
- If no reference result exists, the filtered results remain unchanged

Example: https://resolver.ensembl.org/id/ENSP00000263100